### PR TITLE
Fixing pe file loading

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -148,11 +148,8 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 Settings.LoggingLevel.Verbose);
 
             var source = tests.First().Source;
-            var nfUnitTestLauncherLocation = source.Replace(Path.GetFileName(source), "nanoFramework.UnitTestLauncher.pe");
-            var workingDirectory = Path.GetDirectoryName(nfUnitTestLauncherLocation);
-            var mscorlibLocation = source.Replace(Path.GetFileName(source), "mscorlib.pe");
-            var nfTestFrameworkLocation = source.Replace(Path.GetFileName(source), "nanoFramework.TestFramework.pe");
-            var nfAssemblyUnderTestLocation = source.Replace(".dll", ".pe");
+            var allPeFiles = Directory.GetFiles(Path.GetFileName(source), "*.pe");            
+            var workingDirectory = Path.GetDirectoryName(source);
 
             // prepare the process start of the WIN32 nanoCLR
             _nanoClr = new Process();
@@ -169,7 +166,13 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 // 2. mscorlib
                 // 3. test framework
                 // 4. test application
-                string parameter = $"-load {nfUnitTestLauncherLocation} -load {mscorlibLocation} -load {nfTestFrameworkLocation} -load {nfAssemblyUnderTestLocation}";
+                StringBuilder str = new StringBuilder();
+                foreach(var pe in allPeFiles)
+                {
+                    str.Append($" -load {pe}");
+                }
+
+                string parameter = str.ToString();
 
                 _logger.LogMessage(
                     "Launching process with nanoCLR...",


### PR DESCRIPTION
Fixing pe file loading

## Description

Fixing pe file loading by loading all the pe files present in the directory

## Motivation and Context

- fixing bug when multiple assemblies need to be loaded. By default, after a build, all the needed assemblies are in the output. So just using this mechanism 

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
