### PR TITLE
Fixing path for pe loading

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -169,7 +169,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 StringBuilder str = new StringBuilder();
                 foreach(var pe in allPeFiles)
                 {
-                    str.Append($" -load {pe}");
+                    str.Append($" -load {Path.Combine(workingDirectory, pe)}");
                 }
 
                 string parameter = str.ToString();


### PR DESCRIPTION
Fixing path for pe loading

## Description

Fixing path for pe loading

## Motivation and Context

- Issue introduce by previous assembly loading on path. Fixing this bug

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
