### PR TITLE
Adjusting TestAdapter logging, adding personal message to Assert

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,8 @@ jobs:
   variables:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     buildPlatform: 'Any CPU'
-    buildConfiguration: 'Debug'
+    buildConfiguration: 'Release'
+    buildConfigurationUnitLauncher: 'Debug'
 
   steps:
 
@@ -137,7 +138,7 @@ jobs:
       solution: 'nanoFramework.TestFramework.sln'
       platform: '$(buildPlatform)'
       msbuildArgs: '/p:PublicRelease=true'
-      configuration: '$(buildConfiguration)'
+      configuration: '$(buildConfigurationUnitLauncher)'
   
   # - task: VisualStudioTestPlatformInstaller@1
   #   condition: succeeded()

--- a/poc/TestOfTestFramework/NFUnitTest.nfproj
+++ b/poc/TestOfTestFramework/NFUnitTest.nfproj
@@ -36,13 +36,13 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=1.0.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.TestFramework.1.0.25\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=1.0.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.TestFramework.1.0.59\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.TestFramework.1.0.25\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\packages\nanoFramework.TestFramework.1.0.59\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/poc/TestOfTestFramework/Test.cs
+++ b/poc/TestOfTestFramework/Test.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace nanoFramework.TestFramework.Test
 {
@@ -17,6 +18,20 @@ namespace nanoFramework.TestFramework.Test
         {
             Debug.WriteLine("Test will raise exception");
             Assert.Trows(typeof(Exception), ThrowMe);
+            Assert.Trows(typeof(ArgumentOutOfRangeException), () =>
+            {
+                Debug.WriteLine("To see another way of doing this");
+                // This should throw an ArgumentException
+                Thread.Sleep(-2);
+            });
+            try
+            {
+                Assert.Trows(typeof(Exception), () => { Debug.WriteLine("Nothing will be thrown"); });
+            }
+            catch (Exception)
+            {
+                Debug.WriteLine("Exception raised, perfect");
+            }
         }
 
         private void ThrowMe()

--- a/poc/TestOfTestFramework/packages.config
+++ b/poc/TestOfTestFramework/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.TestFramework" version="1.0.25" targetFramework="netnanoframework10" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="1.0.59" targetFramework="netnanoframework10" developmentDependency="true" />
 </packages>

--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -132,10 +132,12 @@ namespace nanoFramework.TestPlatform.TestAdapter
         {
             List<TestResult> results = PrepareListResult(tests);
             List<byte[]> assemblies = new List<byte[]>();
+            int retryCount = 0;
             string port = _settings.RealHardwarePort == string.Empty ? "COM4" : _settings.RealHardwarePort;
             //var serialDebugClient = PortBase.CreateInstanceForSerial("", null, true, new List<string>() { port });
             var serialDebugClient = PortBase.CreateInstanceForSerial("", null, true, null);
 
+        retryConnection:
             _logger.LogMessage($"Checking device on port {port}.", Settings.LoggingLevel.Verbose);
             while (!serialDebugClient.IsDevicesEnumerationComplete)
             {
@@ -144,14 +146,32 @@ namespace nanoFramework.TestPlatform.TestAdapter
 
             _logger.LogMessage($"Found: {serialDebugClient.NanoFrameworkDevices.Count} devices", Settings.LoggingLevel.Verbose);
 
-            if(serialDebugClient.NanoFrameworkDevices.Count == 0)
+            if (serialDebugClient.NanoFrameworkDevices.Count == 0)
             {
-                results.First().Outcome = TestOutcome.Failed;
-                results.First().ErrorMessage = $"Couldn't find any device, please try to disable the device scanning in the Visual Studio Extension! If the situation persists reboot the device as well.";
-                return results;
+                if (retryCount > _numberOfRetries)
+                {
+                    results.First().Outcome = TestOutcome.Failed;
+                    results.First().ErrorMessage = $"Couldn't find any device, please try to disable the device scanning in the Visual Studio Extension! If the situation persists reboot the device as well.";
+                    return results;
+                }
+                else
+                {
+                    retryCount++;
+                    serialDebugClient.ReScanDevices();
+                    goto retryConnection;
+                }
             }
 
-            var device = serialDebugClient.NanoFrameworkDevices[0];
+            retryCount = 0;
+            NanoDeviceBase device;
+            if (serialDebugClient.NanoFrameworkDevices.Count > 1)
+            {
+                device = serialDebugClient.NanoFrameworkDevices.Where(m => m.SerialNumber == port).First();
+            }
+            else
+            {
+                device = serialDebugClient.NanoFrameworkDevices[0];
+            }
 
             // check if debugger engine exists
             if (device.DebugEngine == null)
@@ -160,269 +180,300 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 _logger.LogMessage($"Debug engine created.", Settings.LoggingLevel.Verbose);
             }
 
-            bool deviceIsInInitializeState = false;
-            int retryCount = 0;
+            bool deviceIsInInitializeState = false;            
 
+        retryDebug:
             bool connectResult = await device.DebugEngine.ConnectAsync(5000, true);
-            _logger.LogMessage($"Device connect result is {connectResult}.", Settings.LoggingLevel.Verbose);
+            _logger.LogMessage($"Device connect result is {connectResult}. Attempt {retryCount}/{_numberOfRetries}", Settings.LoggingLevel.Verbose);
 
-            if (connectResult)
+            if (!connectResult)
             {
-                // erase the device
-                var eraseResult = await Task.Run(async delegate
+                if (retryCount < _numberOfRetries)
                 {
-                    _logger.LogMessage($"Erase deployment block storage.", Settings.LoggingLevel.Error);
-                    return await device.EraseAsync(
-                        EraseOptions.Deployment,
-                        CancellationToken.None,
-                        null,
-                        null);
-                });
-
-                _logger.LogMessage($"Erase result is {eraseResult}.", Settings.LoggingLevel.Verbose);
-                if (eraseResult)
+                    // Give it a bit of time
+                    await Task.Delay(100);
+                    retryCount++;
+                    goto retryDebug;
+                }
+                else
                 {
-
-                    // initial check 
-                    if (device.DebugEngine.IsDeviceInInitializeState())
-                    {
-                        _logger.LogMessage($"Device status verified as being in initialized state. Requesting to resume execution.", Settings.LoggingLevel.Error);
-                        // set flag
-                        deviceIsInInitializeState = true;
-
-                        // device is still in initialization state, try resume execution
-                        device.DebugEngine.ResumeExecution();
-                    }
-
-                    // handle the workflow required to try resuming the execution on the device
-                    // only required if device is not already there
-                    // retry 5 times with a 500ms interval between retries
-                    while (retryCount++ < _numberOfRetries && deviceIsInInitializeState)
-                    {
-                        if (!device.DebugEngine.IsDeviceInInitializeState())
-                        {
-                            _logger.LogMessage($"Device has completed initialization.", Settings.LoggingLevel.Verbose);
-                            // done here
-                            deviceIsInInitializeState = false;
-                            break;
-                        }
-
-                        _logger.LogMessage($"Waiting for device to report initialization completed ({retryCount}/{_numberOfRetries}).", Settings.LoggingLevel.Verbose);
-                        // provide feedback to user on the 1st pass
-                        if (retryCount == 0)
-                        {
-                            _logger.LogMessage($"Waiting for device to initialize.", Settings.LoggingLevel.Verbose);
-                        }
-
-                        if (device.DebugEngine.IsConnectedTonanoBooter)
-                        {
-                            _logger.LogMessage($"Device reported running nanoBooter. Requesting to load nanoCLR.", Settings.LoggingLevel.Verbose);
-                            // request nanoBooter to load CLR
-                            device.DebugEngine.ExecuteMemory(0);
-                        }
-                        else if (device.DebugEngine.IsConnectedTonanoCLR)
-                        {
-                            _logger.LogMessage($"Device reported running nanoCLR. Requesting to reboot nanoCLR.", Settings.LoggingLevel.Error);
-                            await Task.Run(delegate
-                            {
-                                // already running nanoCLR try rebooting the CLR
-                                device.DebugEngine.RebootDevice(RebootOptions.ClrOnly);
-                            });
-                        }
-
-                        // wait before next pass
-                        // use a back-off strategy of increasing the wait time to accommodate slower or less responsive targets (such as networked ones)
-                        await Task.Delay(TimeSpan.FromMilliseconds(_timeoutMiliseconds * (retryCount + 1)));
-
-                        await Task.Yield();
-                    }
-
-                    // check if device is still in initialized state
-                    if (!deviceIsInInitializeState)
-                    {
-                        // device has left initialization state
-                        _logger.LogMessage($"Device is initialized and ready!", Settings.LoggingLevel.Verbose);
-                        await Task.Yield();
-
-
-                        //////////////////////////////////////////////////////////
-                        // sanity check for devices without native assemblies ?!?!
-                        if (device.DeviceInfo.NativeAssemblies.Count == 0)
-                        {
-                            _logger.LogMessage($"Device reporting no assemblies loaded. This can not happen. Sanity check failed.", Settings.LoggingLevel.Error);
-                            // there are no assemblies deployed?!
-                            results.First().Outcome = TestOutcome.Failed;
-                            results.First().ErrorMessage = $"Couldn't find any native assemblies deployed in {device.Description}, {device.TargetName} on {device.SerialNumber}! If the situation persists reboot the device.";
-                            return results;
-                        }
-
-                        _logger.LogMessage($"Computing deployment blob.", Settings.LoggingLevel.Verbose);
-                        // build a list with the full path for each DLL, referenced DLL and EXE
-                        List<DeploymentAssembly> assemblyList = new List<DeploymentAssembly>();
-
-                        var source = tests.First().Source;
-                        var workingDirectory = Path.GetDirectoryName(source);
-                        var allPeFiles = Directory.GetFiles(workingDirectory, "*.pe");
-
-                        // load tests in case we don't need to check the version:
-                        //foreach (var pe in allPeFiles)
-                        //{
-                        //    assemblyList.Add(
-                        //        new DeploymentAssembly(Path.Combine(workingDirectory, pe), "", ""));
-                        //}
-
-                        // TODO do we need to check versions?
-                        var decompilerSettings = new DecompilerSettings
-                        {
-                            LoadInMemory = false,
-                            ThrowOnAssemblyResolveErrors = false
-                        };
-
-                        foreach (string assemblyPath in allPeFiles)
-                        {
-                            // load assembly in order to get the versions
-                            var file = Path.Combine(workingDirectory, assemblyPath.Replace(".pe", ".dll"));
-                            if (!File.Exists(file))
-                            {
-                                // Check with an exe
-                                file = Path.Combine(workingDirectory, assemblyPath.Replace(".pe", ".exe"));
-                            }
-
-                            var decompiler = new CSharpDecompiler(file, decompilerSettings); ;
-                            var assemblyProperties = decompiler.DecompileModuleAndAssemblyAttributesToString();
-
-                            // read attributes using a Regex
-
-                            // AssemblyVersion
-                            string pattern = @"(?<=AssemblyVersion\("")(.*)(?=\""\)])";
-                            var match = Regex.Matches(assemblyProperties, pattern, RegexOptions.IgnoreCase);
-                            string assemblyVersion = match[0].Value;
-
-                            // AssemblyNativeVersion
-                            pattern = @"(?<=AssemblyNativeVersion\("")(.*)(?=\""\)])";
-                            match = Regex.Matches(assemblyProperties, pattern, RegexOptions.IgnoreCase);
-
-                            // only class libs have this attribute, therefore sanity check is required
-                            string nativeVersion = "";
-                            if (match.Count == 1)
-                            {
-                                nativeVersion = match[0].Value;
-                            }
-
-                            assemblyList.Add(new DeploymentAssembly(Path.Combine(workingDirectory, assemblyPath), assemblyVersion, nativeVersion));
-                        }
-
-                        _logger.LogMessage($"Added {assemblyList.Count} assemblies to deploy.", Settings.LoggingLevel.Verbose);
-                        await Task.Yield();
-
-                        // Keep track of total assembly size
-                        long totalSizeOfAssemblies = 0;
-
-                        // TODO use this code to load the PE files
-
-                        // now we will re-deploy all system assemblies
-                        foreach (DeploymentAssembly peItem in assemblyList)
-                        {
-                            // append to the deploy blob the assembly
-                            using (FileStream fs = File.Open(peItem.Path, FileMode.Open, FileAccess.Read))
-                            {
-                                long length = (fs.Length + 3) / 4 * 4;
-                                _logger.LogMessage($"Adding {Path.GetFileNameWithoutExtension(peItem.Path)} v{peItem.Version} ({length} bytes) to deployment bundle", Settings.LoggingLevel.Verbose);
-                                byte[] buffer = new byte[length];
-
-                                await Task.Yield();
-
-                                await fs.ReadAsync(buffer, 0, (int)fs.Length);
-                                assemblies.Add(buffer);
-
-                                // Increment totalizer
-                                totalSizeOfAssemblies += length;
-                            }
-                        }
-
-                        _logger.LogMessage($"Deploying {assemblyList.Count:N0} assemblies to device... Total size in bytes is {totalSizeOfAssemblies}.", Settings.LoggingLevel.Verbose);
-                        // need to keep a copy of the deployment blob for the second attempt (if needed)
-                        var assemblyCopy = new List<byte[]>(assemblies);
-
-                        await Task.Yield();
-
-                        await Task.Run(async delegate
-                        {
-                            // OK to skip erase as we just did that
-                            // no need to reboot device
-                            if (!device.DebugEngine.DeploymentExecute(
-                                assemblyCopy,
-                                false,
-                                true,
-                                null,
-                                null))
-                            {
-                                // if the first attempt fails, give it another try
-
-                                // wait before next pass
-                                await Task.Delay(TimeSpan.FromSeconds(1));
-
-                                await Task.Yield();
-
-                                _logger.LogMessage("Deploying assemblies. Second attempt.", Settings.LoggingLevel.Verbose);
-
-                                // !! need to use the deployment blob copy
-                                assemblyCopy = new List<byte[]>(assemblies);
-
-                                // can't skip erase as we just did that
-                                // no need to reboot device
-                                if (!device.DebugEngine.DeploymentExecute(
-                                    assemblyCopy,
-                                    false,
-                                    false,
-                                    null,
-                                    null))
-                                {
-                                    _logger.LogMessage("Deployment failed.", Settings.LoggingLevel.Error);
-
-                                    // throw exception to signal deployment failure
-                                    results.First().Outcome = TestOutcome.Failed;
-                                    results.First().ErrorMessage = $"Deployment failed in {device.Description}, {device.TargetName} on {device.SerialNumber}! If the situation persists reboot the device.";
-                                }
-                            }
-                        });
-
-                        await Task.Yield();
-                        // If there has been an issue before, the first test is marked as failed
-                        if (results.First().Outcome == TestOutcome.Failed)
-                        {
-                            return results;
-                        }
-
-                        StringBuilder output = new StringBuilder();
-                        bool isFinished = false;
-                        // attach listner for messages
-                        device.DebugEngine.OnMessage += (message, text) =>
-                        {
-                            _logger.LogMessage(text, Settings.LoggingLevel.Verbose);
-                            output.AppendLine(text);
-                            if (text.Contains(Done))
-                            {
-                                isFinished = true;
-                            }
-                        };
-
-                        device.DebugEngine.RebootDevice(RebootOptions.ClrOnly);
-
-                        while (!isFinished)
-                        {
-                            Thread.Sleep(1);
-                        }
-
-                        _logger.LogMessage($"Tests finished.", Settings.LoggingLevel.Verbose);
-                        CheckAllTests(output.ToString(), results);
-                    }
-                    else
-                    {
-                        _logger.LogMessage("Failed to initialize device.", Settings.LoggingLevel.Error);
-                    }
+                    results.First().Outcome = TestOutcome.Failed;
+                    results.First().ErrorMessage = $"Couldn't connect to the device, please try to disable the device scanning in the Visual Studio Extension! If the situation persists reboot the device as well.";
+                    return results;
                 }
             }
+
+            retryCount = 0;
+        retryErase:
+            // erase the device
+            var eraseResult = await Task.Run(async delegate
+            {
+                _logger.LogMessage($"Erase deployment block storage. Attempt {retryCount}/{_numberOfRetries}.", Settings.LoggingLevel.Verbose);
+                return await device.EraseAsync(
+                    EraseOptions.Deployment,
+                    CancellationToken.None,
+                    null,
+                    null);
+            });
+
+            _logger.LogMessage($"Erase result is {eraseResult}.", Settings.LoggingLevel.Verbose);
+            if (!eraseResult)
+            {
+                if (retryCount < _numberOfRetries)
+                {
+                    // Give it a bit of time
+                    await Task.Delay(400);
+                    retryCount++;
+                    goto retryErase;
+                }
+                else
+                {
+                    results.First().Outcome = TestOutcome.Failed;
+                    results.First().ErrorMessage = $"Couldn't erase the device, please try to disable the device scanning in the Visual Studio Extension! If the situation persists reboot the device as well.";
+                    return results;
+                }
+            }
+
+            retryCount = 0;
+            // initial check 
+            if (device.DebugEngine.IsDeviceInInitializeState())
+            {
+                    _logger.LogMessage($"Device status verified as being in initialized state. Requesting to resume execution. Attempt {retryCount}/{_numberOfRetries}.", Settings.LoggingLevel.Error);
+                    // set flag
+                    deviceIsInInitializeState = true;
+
+                    // device is still in initialization state, try resume execution
+                    device.DebugEngine.ResumeExecution();
+            }
+
+            // handle the workflow required to try resuming the execution on the device
+            // only required if device is not already there
+            // retry 5 times with a 500ms interval between retries
+            while (retryCount++ < _numberOfRetries && deviceIsInInitializeState)
+            {
+                if (!device.DebugEngine.IsDeviceInInitializeState())
+                {
+                    _logger.LogMessage($"Device has completed initialization.", Settings.LoggingLevel.Verbose);
+                    // done here
+                    deviceIsInInitializeState = false;
+                    break;
+                }
+
+                _logger.LogMessage($"Waiting for device to report initialization completed ({retryCount}/{_numberOfRetries}).", Settings.LoggingLevel.Verbose);
+                // provide feedback to user on the 1st pass
+                if (retryCount == 0)
+                {
+                    _logger.LogMessage($"Waiting for device to initialize.", Settings.LoggingLevel.Verbose);
+                }
+
+                if (device.DebugEngine.IsConnectedTonanoBooter)
+                {
+                    _logger.LogMessage($"Device reported running nanoBooter. Requesting to load nanoCLR.", Settings.LoggingLevel.Verbose);
+                    // request nanoBooter to load CLR
+                    device.DebugEngine.ExecuteMemory(0);
+                }
+                else if (device.DebugEngine.IsConnectedTonanoCLR)
+                {
+                    _logger.LogMessage($"Device reported running nanoCLR. Requesting to reboot nanoCLR.", Settings.LoggingLevel.Error);
+                    await Task.Run(delegate
+                    {
+                        // already running nanoCLR try rebooting the CLR
+                        device.DebugEngine.RebootDevice(RebootOptions.ClrOnly);
+                    });
+                }
+
+                // wait before next pass
+                // use a back-off strategy of increasing the wait time to accommodate slower or less responsive targets (such as networked ones)
+                await Task.Delay(TimeSpan.FromMilliseconds(_timeoutMiliseconds * (retryCount + 1)));
+
+                await Task.Yield();
+            }
+
+            // check if device is still in initialized state
+            if (!deviceIsInInitializeState)
+            {
+                // device has left initialization state
+                _logger.LogMessage($"Device is initialized and ready!", Settings.LoggingLevel.Verbose);
+                await Task.Yield();
+
+
+                //////////////////////////////////////////////////////////
+                // sanity check for devices without native assemblies ?!?!
+                if (device.DeviceInfo.NativeAssemblies.Count == 0)
+                {
+                    _logger.LogMessage($"Device reporting no assemblies loaded. This can not happen. Sanity check failed.", Settings.LoggingLevel.Error);
+                    // there are no assemblies deployed?!
+                    results.First().Outcome = TestOutcome.Failed;
+                    results.First().ErrorMessage = $"Couldn't find any native assemblies deployed in {device.Description}, {device.TargetName} on {device.SerialNumber}! If the situation persists reboot the device.";
+                    return results;
+                }
+
+                _logger.LogMessage($"Computing deployment blob.", Settings.LoggingLevel.Verbose);
+                // build a list with the full path for each DLL, referenced DLL and EXE
+                List<DeploymentAssembly> assemblyList = new List<DeploymentAssembly>();
+
+                var source = tests.First().Source;
+                var workingDirectory = Path.GetDirectoryName(source);
+                var allPeFiles = Directory.GetFiles(workingDirectory, "*.pe");
+
+                // load tests in case we don't need to check the version:
+                //foreach (var pe in allPeFiles)
+                //{
+                //    assemblyList.Add(
+                //        new DeploymentAssembly(Path.Combine(workingDirectory, pe), "", ""));
+                //}
+
+                // TODO do we need to check versions?
+                var decompilerSettings = new DecompilerSettings
+                {
+                    LoadInMemory = false,
+                    ThrowOnAssemblyResolveErrors = false
+                };
+
+                foreach (string assemblyPath in allPeFiles)
+                {
+                    // load assembly in order to get the versions
+                    var file = Path.Combine(workingDirectory, assemblyPath.Replace(".pe", ".dll"));
+                    if (!File.Exists(file))
+                    {
+                        // Check with an exe
+                        file = Path.Combine(workingDirectory, assemblyPath.Replace(".pe", ".exe"));
+                    }
+
+                    var decompiler = new CSharpDecompiler(file, decompilerSettings); ;
+                    var assemblyProperties = decompiler.DecompileModuleAndAssemblyAttributesToString();
+
+                    // read attributes using a Regex
+
+                    // AssemblyVersion
+                    string pattern = @"(?<=AssemblyVersion\("")(.*)(?=\""\)])";
+                    var match = Regex.Matches(assemblyProperties, pattern, RegexOptions.IgnoreCase);
+                    string assemblyVersion = match[0].Value;
+
+                    // AssemblyNativeVersion
+                    pattern = @"(?<=AssemblyNativeVersion\("")(.*)(?=\""\)])";
+                    match = Regex.Matches(assemblyProperties, pattern, RegexOptions.IgnoreCase);
+
+                    // only class libs have this attribute, therefore sanity check is required
+                    string nativeVersion = "";
+                    if (match.Count == 1)
+                    {
+                        nativeVersion = match[0].Value;
+                    }
+
+                    assemblyList.Add(new DeploymentAssembly(Path.Combine(workingDirectory, assemblyPath), assemblyVersion, nativeVersion));
+                }
+
+                _logger.LogMessage($"Added {assemblyList.Count} assemblies to deploy.", Settings.LoggingLevel.Verbose);
+                await Task.Yield();
+
+                // Keep track of total assembly size
+                long totalSizeOfAssemblies = 0;
+
+                // TODO use this code to load the PE files
+
+                // now we will re-deploy all system assemblies
+                foreach (DeploymentAssembly peItem in assemblyList)
+                {
+                    // append to the deploy blob the assembly
+                    using (FileStream fs = File.Open(peItem.Path, FileMode.Open, FileAccess.Read))
+                    {
+                        long length = (fs.Length + 3) / 4 * 4;
+                        _logger.LogMessage($"Adding {Path.GetFileNameWithoutExtension(peItem.Path)} v{peItem.Version} ({length} bytes) to deployment bundle", Settings.LoggingLevel.Verbose);
+                        byte[] buffer = new byte[length];
+
+                        await Task.Yield();
+
+                        await fs.ReadAsync(buffer, 0, (int)fs.Length);
+                        assemblies.Add(buffer);
+
+                        // Increment totalizer
+                        totalSizeOfAssemblies += length;
+                    }
+                }
+
+                _logger.LogMessage($"Deploying {assemblyList.Count:N0} assemblies to device... Total size in bytes is {totalSizeOfAssemblies}.", Settings.LoggingLevel.Verbose);
+                // need to keep a copy of the deployment blob for the second attempt (if needed)
+                var assemblyCopy = new List<byte[]>(assemblies);
+
+                await Task.Yield();
+
+                await Task.Run(async delegate
+                {
+                    // OK to skip erase as we just did that
+                    // no need to reboot device
+                    if (!device.DebugEngine.DeploymentExecute(
+                    assemblyCopy,
+                    false,
+                    true,
+                    null,
+                    null))
+                    {
+                        // if the first attempt fails, give it another try
+
+                        // wait before next pass
+                        await Task.Delay(TimeSpan.FromSeconds(1));
+
+                        await Task.Yield();
+
+                        _logger.LogMessage("Deploying assemblies. Second attempt.", Settings.LoggingLevel.Verbose);
+
+                        // !! need to use the deployment blob copy
+                        assemblyCopy = new List<byte[]>(assemblies);
+
+                        // can't skip erase as we just did that
+                        // no need to reboot device
+                        if (!device.DebugEngine.DeploymentExecute(
+                        assemblyCopy,
+                        false,
+                        false,
+                        null,
+                        null))
+                        {
+                            _logger.LogMessage("Deployment failed.", Settings.LoggingLevel.Error);
+
+                            // throw exception to signal deployment failure
+                            results.First().Outcome = TestOutcome.Failed;
+                            results.First().ErrorMessage = $"Deployment failed in {device.Description}, {device.TargetName} on {device.SerialNumber}! If the situation persists reboot the device.";
+                        }
+                    }
+                });
+
+                await Task.Yield();
+                // If there has been an issue before, the first test is marked as failed
+                if (results.First().Outcome == TestOutcome.Failed)
+                {
+                    return results;
+                }
+
+                StringBuilder output = new StringBuilder();
+                bool isFinished = false;
+                // attach listner for messages
+                device.DebugEngine.OnMessage += (message, text) =>
+                {
+                    _logger.LogMessage(text, Settings.LoggingLevel.Verbose);
+                    output.Append(text);
+                    if (text.Contains(Done))
+                    {
+                        isFinished = true;
+                    }
+                };
+
+                device.DebugEngine.RebootDevice(RebootOptions.ClrOnly);
+
+                while (!isFinished)
+                {
+                    Thread.Sleep(1);
+                }
+
+                _logger.LogMessage($"Tests finished.", Settings.LoggingLevel.Verbose);
+                CheckAllTests(output.ToString(), results);
+            }
+            else
+            {
+                _logger.LogMessage("Failed to initialize device.", Settings.LoggingLevel.Error);
+            }
+
 
             return results;
         }
@@ -564,7 +615,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 _nanoClr.WaitForExit(runTimeout);
 
                 CheckAllTests(output.ToString(), results);
-
+                _logger.LogMessage(output.ToString(), Settings.LoggingLevel.Verbose);
                 if (!output.ToString().Contains(Done))
                 {
                     results.First().Outcome = TestOutcome.Failed;

--- a/source/TestFramework/TestFramework.cs
+++ b/source/TestFramework/TestFramework.cs
@@ -22,14 +22,14 @@ namespace nanoFramework.TestFramework
         /// </summary>
         /// <param name="condition">The condition to check</param>
         /// <exception cref="Exception">Raises an exception if the condition is not true</exception>
-        public static void True(bool condition)
+        public static void True(bool condition, string message = "")
         {
             if (condition)
             {
                 return;
             }
 
-            throw new Exception($"{condition} is not true");
+            throw new Exception($"{condition} is not true. {message}");
         }
 
         /// <summary>
@@ -37,14 +37,14 @@ namespace nanoFramework.TestFramework
         /// </summary>
         /// <param name="condition">The condition to check</param>
         /// <exception cref="Exception">Raises an exception if the condition is not false</exception>
-        public static void False(bool condition)
+        public static void False(bool condition, string message = "")
         {
             if (!condition)
             {
                 return;
             }
 
-            throw new Exception($"{condition} is not false");
+            throw new Exception($"{condition} is not false. {message}");
         }
 
         #endregion
@@ -57,14 +57,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(bool a, bool b)
+        public static void Equal(bool a, bool b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -73,14 +73,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(int a, int b)
+        public static void Equal(int a, int b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -89,14 +89,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(Array a, Array b)
+        public static void Equal(Array a, Array b, string message = "")
         {
             if (a.SequenceEqual(b))
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -105,14 +105,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(uint a, uint b)
+        public static void Equal(uint a, uint b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -121,14 +121,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(short a, short b)
+        public static void Equal(short a, short b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -137,14 +137,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(ushort a, ushort b)
+        public static void Equal(ushort a, ushort b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -153,14 +153,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(long a, long b)
+        public static void Equal(long a, long b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -169,14 +169,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(ulong a, ulong b)
+        public static void Equal(ulong a, ulong b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -185,14 +185,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(byte a, byte b)
+        public static void Equal(byte a, byte b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -201,14 +201,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(char a, char b)
+        public static void Equal(char a, char b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -217,14 +217,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(sbyte a, sbyte b)
+        public static void Equal(sbyte a, sbyte b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -233,14 +233,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(double a, double b)
+        public static void Equal(double a, double b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -249,14 +249,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(float a, float b)
+        public static void Equal(float a, float b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -265,14 +265,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void Equal(string a, string b)
+        public static void Equal(string a, string b, string message = "")
         {
             if (a == b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         #endregion
@@ -285,14 +285,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(bool a, bool b)
+        public static void NotEqual(bool a, bool b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -301,14 +301,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(int a, int b)
+        public static void NotEqual(int a, int b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -317,14 +317,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(Array a, Array b)
+        public static void NotEqual(Array a, Array b, string message = "")
         {
             if (!a.SequenceEqual(b))
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -333,14 +333,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are not equal</exception>
-        public static void NotEqual(uint a, uint b)
+        public static void NotEqual(uint a, uint b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -349,14 +349,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(short a, short b)
+        public static void NotEqual(short a, short b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -365,14 +365,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(ushort a, ushort b)
+        public static void NotEqual(ushort a, ushort b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -381,14 +381,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(long a, long b)
+        public static void NotEqual(long a, long b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -397,14 +397,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(ulong a, ulong b)
+        public static void NotEqual(ulong a, ulong b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -413,14 +413,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(byte a, byte b)
+        public static void NotEqual(byte a, byte b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -429,14 +429,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(char a, char b)
+        public static void NotEqual(char a, char b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -445,14 +445,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(sbyte a, sbyte b)
+        public static void NotEqual(sbyte a, sbyte b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -461,14 +461,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(double a, double b)
+        public static void NotEqual(double a, double b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -477,14 +477,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(float a, float b)
+        public static void NotEqual(float a, float b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         /// <summary>
@@ -493,14 +493,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">First element</param>
         /// <param name="b">Second element</param>
         /// <exception cref="Exception">Raises an exception if both elements are equal</exception>
-        public static void NotEqual(string a, string b)
+        public static void NotEqual(string a, string b, string message = "")
         {
             if (a != b)
             {
                 return;
             }
 
-            throw new Exception($"{a} is not equal to {b}");
+            throw new Exception($"{a} is not equal to {b}. {message}");
         }
 
         #endregion
@@ -513,14 +513,14 @@ namespace nanoFramework.TestFramework
         /// <param name="expected">The expected string</param>
         /// <param name="actual">The actual string to check</param>
         /// <exception cref="Exception">Raises an exception if the expected string is not included in the actual</exception>
-        public static void Contains(string expected, string actual)
+        public static void Contains(string expected, string actual, string message = "")
         {
             if (actual.IndexOf(expected) >= 0)
             {
                 return;
             }
 
-            throw new Exception($"{actual} does not contains {expected}");
+            throw new Exception($"{actual} does not contains {expected}. {message}");
         }
 
         /// <summary>
@@ -529,7 +529,7 @@ namespace nanoFramework.TestFramework
         /// <param name="expected">The expected string</param>
         /// <param name="actual">The actual string to check</param>
         /// <exception cref="Exception">Raises an exception if the expected string is included in the actual</exception>
-        public static void DoesNotContains(string expected, string actual)
+        public static void DoesNotContains(string expected, string actual, string message = "")
         {
             if (actual == null)
             {
@@ -541,7 +541,7 @@ namespace nanoFramework.TestFramework
                 return;
             }
 
-            throw new Exception($"{actual} does not contains {expected}");
+            throw new Exception($"{actual} does not contains {expected}. {message}");
         }
 
         /// <summary>
@@ -550,7 +550,7 @@ namespace nanoFramework.TestFramework
         /// <param name="expected">The expected string</param>
         /// <param name="actual">The actual string to check</param>
         /// <exception cref="Exception">Raises an exception if the expected string is not at the end of the actual string</exception>
-        public static void EndsWith(string expected, string actual)
+        public static void EndsWith(string expected, string actual, string message = "")
         {
             // We have to take the last index as the text can contains multiple times the same word
             if (actual.LastIndexOf(expected) == actual.Length - expected.Length)
@@ -558,7 +558,7 @@ namespace nanoFramework.TestFramework
                 return;
             }
 
-            throw new Exception($"{actual} does not ends with {expected}");
+            throw new Exception($"{actual} does not ends with {expected}. {message}");
         }
 
         /// <summary>
@@ -567,14 +567,14 @@ namespace nanoFramework.TestFramework
         /// <param name="expected">The expected string</param>
         /// <param name="actual">The actual string to check</param>
         /// <exception cref="Exception">Raises an exception if the expected string is not at the end of the actual string</exception>
-        public static void StartsWith(string expected, string actual)
+        public static void StartsWith(string expected, string actual, string message = "")
         {
             if (actual.IndexOf(expected) == 0)
             {
                 return;
             }
 
-            throw new Exception($"{actual} does not starts with {expected}");
+            throw new Exception($"{actual} does not starts with {expected}. {message}");
         }
 
         #endregion
@@ -586,14 +586,14 @@ namespace nanoFramework.TestFramework
         /// </summary>
         /// <param name="collection">The collection to check</param>
         /// <exception cref="Exception">Raises an exception if the collection is not empty</exception>
-        public static void Empty(ICollection collection)
+        public static void Empty(ICollection collection, string message = "")
         {
             if (collection.Count == 0)
             {
                 return;
             }
 
-            throw new Exception($"{collection} is not empty");
+            throw new Exception($"{collection} is not empty. {message}");
         }
 
         /// <summary>
@@ -601,14 +601,14 @@ namespace nanoFramework.TestFramework
         /// </summary>
         /// <param name="collection">The collection to check</param>
         /// <exception cref="Exception">Raises an exception if the collection is not empty</exception>
-        public static void NotEmpty(ICollection collection)
+        public static void NotEmpty(ICollection collection, string message = "")
         {
             if (collection.Count > 0)
             {
                 return;
             }
 
-            throw new Exception($"{collection} is not empty");
+            throw new Exception($"{collection} is not empty. {message}");
         }
 
         #endregion region
@@ -621,14 +621,14 @@ namespace nanoFramework.TestFramework
         /// <param name="type">The type to check</param>
         /// <param name="obj">The object to check</param>
         /// <exception cref="Exception">Raises an exception if the types are not equal</exception>
-        public static void IsType(Type type, object obj)
+        public static void IsType(Type type, object obj, string message = "")
         {
             if (type == obj.GetType())
             {
                 return;
             }
 
-            throw new Exception($"{obj} is not type of {type}");
+            throw new Exception($"{obj} is not type of {type}. {message}");
         }
 
         /// <summary>
@@ -637,14 +637,14 @@ namespace nanoFramework.TestFramework
         /// <param name="type">The type to check</param>
         /// <param name="obj">The object to check</param>
         /// <exception cref="Exception">Raises an exception if the types are equal</exception>
-        public static void IsNotType(Type type, object obj)
+        public static void IsNotType(Type type, object obj, string message = "")
         {
             if (type != obj.GetType())
             {
                 return;
             }
 
-            throw new Exception($"{obj} is not type of {type}");
+            throw new Exception($"{obj} is not type of {type}. {message}");
         }
 
         /// <summary>
@@ -653,14 +653,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">The first object</param>
         /// <param name="b">The second object</param>
         /// <exception cref="Exception">Raises an exception if the objects are not the same</exception>
-        public static void Same(object a, object b)
+        public static void Same(object a, object b, string message = "")
         {
             if (a.Equals(b))
             {
                 return;
             }
 
-            throw new Exception($"{a} is not the same as {b}");
+            throw new Exception($"{a} is not the same as {b}. {message}");
         }
 
         /// <summary>
@@ -669,14 +669,14 @@ namespace nanoFramework.TestFramework
         /// <param name="a">The first object</param>
         /// <param name="b">The second object</param>
         /// <exception cref="Exception">Raises an exception if the objects are the same</exception>
-        public static void NotSame(object a, object b)
+        public static void NotSame(object a, object b, string message = "")
         {
             if (!a.Equals(b))
             {
                 return;
             }
 
-            throw new Exception($"{a} is the same as {b}");
+            throw new Exception($"{a} is the same as {b}. {message}");
         }
 
         /// <summary>
@@ -684,14 +684,14 @@ namespace nanoFramework.TestFramework
         /// </summary>
         /// <param name="obj">The object to check</param>
         /// <exception cref="Exception">Raises an exception if the object is not null</exception>
-        public static void Null(object obj)
+        public static void Null(object obj, string message = "")
         {
             if (obj == null)
             {
                 return;
             }
 
-            throw new Exception($"{obj} is null");
+            throw new Exception($"{obj} is null. {message}");
         }
 
         /// <summary>
@@ -699,14 +699,14 @@ namespace nanoFramework.TestFramework
         /// </summary>
         /// <param name="obj">The object to check</param>
         /// <exception cref="Exception">Raises an exception if the object is null/exception>
-        public static void NotNull(object obj)
+        public static void NotNull(object obj, string message = "")
         {
             if (obj != null)
             {
                 return;
             }
 
-            throw new Exception($"{obj} is not null");
+            throw new Exception($"{obj} is not null. {message}");
         }
 
         /// <summary>
@@ -714,7 +714,7 @@ namespace nanoFramework.TestFramework
         /// </summary>
         /// <param name="exceptionType">The exception to be raised</param>
         /// <param name="action">The method to execute</param>
-        public static void Trows(Type exceptionType, Action action)
+        public static void Trows(Type exceptionType, Action action, string message = "")
         {
             try
             {
@@ -727,10 +727,10 @@ namespace nanoFramework.TestFramework
                     return;
                 }
 
-                throw new Exception($"An exception {ex.GetType()} has been thrown but is not type {exceptionType}");
+                throw new Exception($"An exception {ex.GetType()} has been thrown but is not type {exceptionType}. {message}");
             }
 
-            throw new Exception($"No exception has been thrown");
+            throw new Exception($"No exception has been thrown. {message}");
         }
 
         #endregion

--- a/source/package.nuspec
+++ b/source/package.nuspec
@@ -22,8 +22,8 @@
     </packageTypes>
   </metadata>
   <files>
-    <file src="TestAdapter\bin\Debug\net4.8\*.dll" target="lib/net48" />
-    <file src="TestAdapter\bin\Debug\net4.8\*.*" target="lib/net48" />
+    <file src="TestAdapter\bin\Release\net4.8\*.dll" target="lib/net48" />
+    <file src="TestAdapter\bin\Release\net4.8\*.*" target="lib/net48" />
 
     <file src="UnitTestLauncher\bin\Debug\nanoFramework.TestFramework.*" target="lib" />
     <file src="UnitTestLauncher\bin\Debug\nanoFramework.UnitTestLauncher.*" target="lib" />


### PR DESCRIPTION
Adjusting TestAdapter logging, adding personal message to Assert

## Description

- Adjusting TestAdapter logging
- Adding personal message to Assert
- Adding retry mechanism for device connection, reset

## Motivation and Context

Improve the TestFramework platform

## How Has This Been Tested?<!-- (if applicable) -->

Local machine

## Screenshots<!-- (if appropriate): -->

## Types of changes

- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
