### PR TITLE
Adjust nanoClr finding path

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -119,7 +119,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 else
                 {
                     // we are connecting to WIN32 nanoCLR
-                    results = RunTest(groups.ToList());
+                    results = RunTestOnEmulator(groups.ToList());
                 }
 
                 foreach (var result in results)
@@ -131,6 +131,10 @@ namespace nanoFramework.TestPlatform.TestAdapter
 
         private async Task<List<TestResult>> RunTestOnHardwareAsync(List<TestCase> tests)
         {
+            _logger.LogMessage(
+                "Setting up test runner in *** CONNECTED DEVICE ***",
+                Settings.LoggingLevel.Detailed);
+
             List<TestResult> results = PrepareListResult(tests);
             List<byte[]> assemblies = new List<byte[]>();
             int retryCount = 0;
@@ -173,6 +177,10 @@ namespace nanoFramework.TestPlatform.TestAdapter
             {
                 device = serialDebugClient.NanoFrameworkDevices[0];
             }
+
+            _logger.LogMessage(
+                $"Getting things with {device.Description}",
+                Settings.LoggingLevel.Detailed);
 
             // check if debugger engine exists
             if (device.DebugEngine == null)
@@ -507,10 +515,10 @@ namespace nanoFramework.TestPlatform.TestAdapter
             return results;
         }
 
-        private List<TestResult> RunTest(List<TestCase> tests)
+        private List<TestResult> RunTestOnEmulator(List<TestCase> tests)
         {
             _logger.LogMessage(
-                "Setting up test runner...",
+                "Setting up test runner in *** nanoCLR WIN32***",
                 Settings.LoggingLevel.Detailed);
 
             int runTimeout = 10000;
@@ -557,7 +565,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 string parameter = str.ToString();
 
                 _logger.LogMessage(
-                    "Launching process with nanoCLR...",
+                    $"Parameters to pass to nanoCLR: <{parameter}>",
                     Settings.LoggingLevel.Verbose);
 
                 var nanoClrLocation = TestObjectHelper.GetNanoClrLocation();
@@ -577,6 +585,10 @@ namespace nanoFramework.TestPlatform.TestAdapter
                     RedirectStandardError = true,
                     RedirectStandardOutput = true
                 };
+
+                _logger.LogMessage(
+                    $"Launching process with nanoCLR (from {Path.GetFullPath(TestObjectHelper.GetNanoClrLocation())})",
+                    Settings.LoggingLevel.Verbose);
 
                 // launch nanoCLR
                 if (!_nanoClr.Start())

--- a/source/TestAdapter/TestObjectHelper.cs
+++ b/source/TestAdapter/TestObjectHelper.cs
@@ -5,6 +5,7 @@
 //
 
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace nanoFramework.TestPlatform.TestAdapter
@@ -14,6 +15,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
     /// </summary>
     public static class TestObjectHelper
     {
+        private const string NanoClrName = "nanoFramework.nanoCLR.exe";
         /// <summary>
         /// Get the execution directory for the nanoCLR.exe
         /// </summary>
@@ -21,9 +23,35 @@ namespace nanoFramework.TestPlatform.TestAdapter
         public static string GetNanoClrLocation()
         {
             var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var nanoClrFullPath = Path.Combine(thisAssemblyDir, "nanoFramework.nanoCLR.exe");
+            var nanoClrFullPath = Path.Combine(thisAssemblyDir, NanoClrName);
+            if (File.Exists(nanoClrFullPath))
+            {
+                return nanoClrFullPath;
+            }
+            else
+            {
+                var inititialDir = new DirectoryInfo(Path.GetDirectoryName(thisAssemblyDir));
+                return FindNanoClr(inititialDir);
+            }
+        }
 
-            return nanoClrFullPath;
+        private static string FindNanoClr(DirectoryInfo initialPath)
+        {
+            var dir = initialPath.Parent;
+            if (dir != null)
+            {
+                var findnanoClr = dir.GetFiles(NanoClrName, SearchOption.AllDirectories);
+                if (findnanoClr.Any())
+                {
+                    return findnanoClr.First().FullName;
+                }
+                else
+                {
+                    return FindNanoClr(dir);
+                }
+            }
+
+            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
## Description

To make sure nanoCLR Win32 will be found on the hard drive. This is mainly done for pipeline run.

## Motivation and Context

- Make sure nanoCLR Win32 will always be found if present on the disk. Should fix the challenge of running it in a pipeline

## How Has This Been Tested?<!-- (if applicable) -->

With local project

## Screenshots<!-- (if appropriate): -->

## Types of changes

- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
