### PR TITLE
Add target to download nanoCLR on build

### DIFF
--- a/poc/TestOfTestFramework/NFUnitTest.nfproj
+++ b/poc/TestOfTestFramework/NFUnitTest.nfproj
@@ -50,10 +50,17 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
-  <Import Project="..\packages\nanoFramework.TestFramework.1.1.2\build\nanoFramework.TestFramework.targets" Condition="Exists('..\packages\nanoFramework.TestFramework.1.1.2\build\nanoFramework.TestFramework.targets')" />
+  <!-- MANUAL UPDATE HERE -->
+  <Import Project="..\packages\nanoFramework.TestFramework.1.1.2\build\nanoFramework.TestFramework.targets"/>
   <ProjectExtensions>
     <ProjectCapabilities>
       <ProjectConfigurationsDeclaredAsItems />
     </ProjectCapabilities>
   </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Update the Import path in nfproj to the correct nanoFramework.TestFramework NuGet package folder.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\nanoFramework.TestFramework.1.1.2\build\nanoFramework.TestFramework.targets')" Text="'$(ErrorText)'" />
+  </Target>
 </Project>

--- a/poc/TestOfTestFramework/NFUnitTest.nfproj
+++ b/poc/TestOfTestFramework/NFUnitTest.nfproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ProjectCapability Include="TestContainer" />
@@ -35,19 +35,22 @@
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.1-preview.11\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=1.0.83.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.TestFramework.1.0.83\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=1.0.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.TestFramework.1.1.2\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.TestFramework.1.0.83\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\packages\nanoFramework.TestFramework.1.1.2\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <Import Project="..\packages\nanoFramework.TestFramework.1.1.2\build\nanoFramework.TestFramework.targets" Condition="Exists('..\packages\nanoFramework.TestFramework.1.1.2\build\nanoFramework.TestFramework.targets')" />
   <ProjectExtensions>
     <ProjectCapabilities>
       <ProjectConfigurationsDeclaredAsItems />

--- a/poc/TestOfTestFramework/packages.config
+++ b/poc/TestOfTestFramework/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.TestFramework" version="1.0.83" targetFramework="netnanoframework10" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="1.1.2" targetFramework="netnanoframework10" developmentDependency="true" />
 </packages>

--- a/source/nanoFramework.TestFramework.targets
+++ b/source/nanoFramework.TestFramework.targets
@@ -1,0 +1,15 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build"  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>  
+      <Win32_nanoClr_Exe>https://bintray.com/nfbot/nanoframework-images-dev/download_file?file_path=nanoFramework.nanoCLR.exe</Win32_nanoClr_Exe>
+    </PropertyGroup>  
+
+    <Target Name="DownloadWin32NanoClrExe" BeforeTargets="Build">
+        <DownloadFile 
+            ContinueOnError="WarnAndContinue"
+            SourceUrl="$(Win32_nanoClr_Exe)"
+            DestinationFileName="nanoFramework.nanoCLR.exe"
+            DestinationFolder="$(MSBuildThisFileDirectory)..\lib\net48">
+        <Output TaskParameter="DownloadedFile" ItemName="Content" />
+      </DownloadFile>
+    </Target>
+</Project>

--- a/source/package.nuspec
+++ b/source/package.nuspec
@@ -30,6 +30,8 @@
 
     <file src="runsettings\nano.runsettings" target="content" />
 
+    <file src="nanoFramework.TestFramework.targets" target="build" />
+
     <file src="..\assets\nf-logo.png" target="images" />
     <file src="..\LICENSE.md" target="" />
 


### PR DESCRIPTION
## Description
- Add target to download nanoCLR file on build.

There is a shortcoming though, derived from the fact that nfproj is not fully supported by nuget. When updating the Test Framework nuget the import path is not automatically updated on the nfproj file. The same goes when adding the Test Framework NuGet package "in cold". The Unit Test template will include this out-of-the-box.
The msbuild tasks is set to continue on error, therefore not being able to download nanoCLR won't ever break the build.
Plus the Test Framework includes a copy of the nanoCLR to make the build possible out-of-the-box and even without the import of the correct target.

## Motivation and Context
- Need to be able to use the latest nanoCLR version without having to constantly update and publish the Test Framework nuget package.

## How Has This Been Tested?<!-- (if applicable) -->
- POC solution.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
