### PR TITLE
Adding skipped test, correcting Assert.Throws

### DIFF
--- a/poc/NFUnit Test DemoByReference.sln
+++ b/poc/NFUnit Test DemoByReference.sln
@@ -1,0 +1,47 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31019.35
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "NFUnitTestByReference", "TestOfTestFrameworkByReference\NFUnitTestByReference.nfproj", "{FBD29C49-D7DC-425E-BAD1-1AE63484A6CD}"
+EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "nanoFramework.TestFramework", "..\source\TestFramework\nanoFramework.TestFramework.nfproj", "{D66A7774-AFAB-466B-9CFB-3485B02F4AF4}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "TestFrameworkShared", "..\source\TestFrameworkShared\TestFrameworkShared.shproj", "{55F048B5-6739-43C5-A93D-DB61DB8E912F}"
+EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "nanoFramework.UnitTestLauncher", "..\source\UnitTestLauncher\nanoFramework.UnitTestLauncher.nfproj", "{897FC4EA-823D-4343-8CC6-B6F28C3FF91E}"
+EndProject
+Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\source\TestFrameworkShared\TestFrameworkShared.projitems*{55f048b5-6739-43c5-a93d-db61db8e912f}*SharedItemsImports = 13
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FBD29C49-D7DC-425E-BAD1-1AE63484A6CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBD29C49-D7DC-425E-BAD1-1AE63484A6CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBD29C49-D7DC-425E-BAD1-1AE63484A6CD}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{FBD29C49-D7DC-425E-BAD1-1AE63484A6CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBD29C49-D7DC-425E-BAD1-1AE63484A6CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBD29C49-D7DC-425E-BAD1-1AE63484A6CD}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{D66A7774-AFAB-466B-9CFB-3485B02F4AF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D66A7774-AFAB-466B-9CFB-3485B02F4AF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D66A7774-AFAB-466B-9CFB-3485B02F4AF4}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{D66A7774-AFAB-466B-9CFB-3485B02F4AF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D66A7774-AFAB-466B-9CFB-3485B02F4AF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D66A7774-AFAB-466B-9CFB-3485B02F4AF4}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{897FC4EA-823D-4343-8CC6-B6F28C3FF91E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{897FC4EA-823D-4343-8CC6-B6F28C3FF91E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{897FC4EA-823D-4343-8CC6-B6F28C3FF91E}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{897FC4EA-823D-4343-8CC6-B6F28C3FF91E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{897FC4EA-823D-4343-8CC6-B6F28C3FF91E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{897FC4EA-823D-4343-8CC6-B6F28C3FF91E}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {280DA13F-AFF7-4D5D-BA7F-BFC5E8F19995}
+	EndGlobalSection
+EndGlobal

--- a/poc/TestOfTestFrameworkByReference/NFUnitTestByReference.nfproj
+++ b/poc/TestOfTestFrameworkByReference/NFUnitTestByReference.nfproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectCapability Include="TestContainer" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>fbd29c49-d7dc-425e-bad1-1ae63484a6cd</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>NFUnitTest</RootNamespace>
+    <AssemblyName>NFUnitTest</AssemblyName>
+    <IsCodedUITest>False</IsCodedUITest>
+    <IsTestProject>true</IsTestProject>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\nano.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SkipFewMethods.cs" />
+    <Compile Include="SkipTestClass.cs" />
+    <Compile Include="Test.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\source\TestFramework\nanoFramework.TestFramework.nfproj" />
+    <ProjectReference Include="..\..\source\UnitTestLauncher\nanoFramework.UnitTestLauncher.nfproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib, Version=1.10.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.1-preview.11\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.5.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Native.1.5.1-preview.30\lib\nanoFramework.Runtime.Native.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="nano.runsettings" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <!-- MANUAL UPDATE HERE -->
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+</Project>

--- a/poc/TestOfTestFrameworkByReference/Properties/AssemblyInfo.cs
+++ b/poc/TestOfTestFrameworkByReference/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CSharp.BlankApplication")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CSharp.BlankApplication")]
+[assembly: AssemblyCopyright("Copyright © ")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+/////////////////////////////////////////////////////////////////
+// This attribute is mandatory when building Interop libraries //
+// update this whenever the native assembly signature changes  //
+[assembly: AssemblyNativeVersion("1.0.0.0")]
+/////////////////////////////////////////////////////////////////

--- a/poc/TestOfTestFrameworkByReference/SkipFewMethods.cs
+++ b/poc/TestOfTestFrameworkByReference/SkipFewMethods.cs
@@ -1,0 +1,63 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.Runtime.Native;
+using nanoFramework.TestFramework;
+using System;
+using System.Diagnostics;
+using static nanoFramework.Runtime.Native.SystemInfo;
+
+namespace NFUnitTest
+{
+    [TestClass]
+    class SkipFewTest
+    {
+        [Setup]
+        public void SetupMethodWillPass()
+        { }
+
+        [TestMethod]
+        public void MethodWillPass1()
+        { }
+
+        [TestMethod]
+        public void MethodWillPass2()
+        { }
+
+        [TestMethod]
+        public void MethodWillSkip()
+        {
+            Assert.SkipTest("This is a good reason: testing the test!");
+        }
+
+        [TestMethod]
+        public void MethodWillSkip2()
+        {
+            Debug.WriteLine("For no reason");
+            Assert.SkipTest();
+        }
+
+        [TestMethod]
+        public void MethodWillPass3()
+        { }
+
+
+        [TestMethod]
+        public void MethodWillSkippIfFloatingPointSupportNotOK()
+        {
+            var sysInfoFloat = SystemInfo.FloatingPointSupport;
+            if ((sysInfoFloat != FloatingPoint.DoublePrecisionHardware) && (sysInfoFloat != FloatingPoint.DoublePrecisionSoftware))
+            {
+                Assert.SkipTest("Double floating point not supported, skipping the Assert.Double test");
+            }
+
+            double on42 = 42.1;
+            double maxDouble = double.MaxValue;
+            Assert.Equal(42.1, on42);
+            Assert.Equal(double.MaxValue, maxDouble);
+        }
+    }
+}

--- a/poc/TestOfTestFrameworkByReference/SkipTestClass.cs
+++ b/poc/TestOfTestFrameworkByReference/SkipTestClass.cs
@@ -1,0 +1,51 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.TestFramework;
+using System;
+using System.Diagnostics;
+
+namespace NFUnitTest
+{
+    [TestClass]
+    class SkipTestClass
+    {
+        [Setup]
+        public void SetupMethodToSkip()
+        {
+            Debug.WriteLine("Skippîng all the other methods");
+            Assert.SkipTest("None of the other methods should be tested, they should all be skipped.");
+        }
+
+        [TestMethod]
+        public void TestMothdWhichShouldSkip()
+        { }
+
+        [TestMethod]
+        public void TestMothdWhichShouldSkip2()
+        { }
+
+        [TestMethod]
+        public void TestMothdWhichShouldSkip3()
+        { }
+
+        [TestMethod]
+        public void TestMothdWhichShouldSkip4()
+        { }
+
+        [TestMethod]
+        public void TestMothdWhichShouldSkip5()
+        { }
+
+        [TestMethod]
+        public void TestMothdWhichShouldSkip6()
+        { }
+
+        [Cleanup]
+        public void CleanUpMethodSkip()
+        { }
+    }
+}

--- a/poc/TestOfTestFrameworkByReference/Test.cs
+++ b/poc/TestOfTestFrameworkByReference/Test.cs
@@ -1,0 +1,187 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace nanoFramework.TestFramework.Test
+{
+    [TestClass]
+    public class TestOfTest
+    {
+        [TestMethod]
+        public void TestRaisesException()
+        {
+            Debug.WriteLine("Test will raise exception");
+            Assert.Throws(typeof(Exception), ThrowMe);
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () =>
+            {
+                Debug.WriteLine("To see another way of doing this");
+                // This should throw an ArgumentException
+                Thread.Sleep(-2);
+            });
+            try
+            {
+                Assert.Throws(typeof(Exception), () => { Debug.WriteLine("Nothing will be thrown"); });
+            }
+            catch (Exception)
+            {
+                Debug.WriteLine("Exception raised, perfect");
+            }
+        }
+
+        private void ThrowMe()
+        {
+            throw new Exception("Test failed and it's a shame");
+        }
+
+        [TestMethod]
+        public void TestCheckAllEqual()
+        {
+            Debug.WriteLine("Test will check that all the Equal are actually equal");
+            // Arrange
+            byte bytea = 42; byte byteb = 42;
+            char chara = (char)42; char charb = (char)42;
+            sbyte sbytea = 42; sbyte sbyteb = 42;
+            int inta = 42; int intb = 42;
+            uint uinta = 42; uint uintb = 42;
+            long longa = 42; long longb = 42;
+            ulong ulonga = 42; ulong ulongb = 42;
+            bool boola = true; bool boolb = true;
+            short shorta = 42; short shortb = 42;
+            ushort ushorta = 42; ushort ushortb = 42;
+            float floata = 42; float floatb = 42;
+            int[] intArraya = new int[5] { 1, 2, 3, 4, 5 };
+            int[] intArrayb = new int[5] { 1, 2, 3, 4, 5 };
+            object obja = new object(); object objb = obja;
+            string stra = "42"; string strb = "42";
+            byte[] arrayempty = new byte[0];
+            // Assert
+            Assert.True(boola);
+            Assert.Equal(bytea, byteb);
+            Assert.Equal(chara, charb);
+            Assert.Equal(sbytea, sbyteb);
+            Assert.Equal(inta, intb);
+            Assert.Equal(uinta, uintb);
+            Assert.Equal(longa, longb);
+            Assert.Equal(ulonga, ulongb);
+            Assert.Equal(boola, boolb);
+            Assert.Equal(shorta, shortb);
+            Assert.Equal(ushorta, ushortb);
+            Assert.Equal(floata, floatb);
+            Assert.Equal(intArraya, intArrayb);
+            Assert.Equal(stra, strb);
+            Assert.Same(obja, objb);
+            Assert.Empty(arrayempty);
+        }
+
+        [TestMethod]
+        public void TestCheckAllNotEqual()
+        {
+            Debug.WriteLine("Test will check that all the NotEqual are actually equal");
+            // Arrange
+            byte bytea = 42; byte byteb = 43;
+            char chara = (char)42; char charb = (char)43;
+            sbyte sbytea = 42; sbyte sbyteb = 43;
+            int inta = 42; int intb = 43;
+            uint uinta = 42; uint uintb = 43;
+            long longa = 42; long longb = 43;
+            ulong ulonga = 42; ulong ulongb = 43;
+            bool boola = true; bool boolb = false;
+            short shorta = 42; short shortb = 43;
+            ushort ushorta = 42; ushort ushortb = 43;
+            float floata = 42; float floatb = 43;
+            int[] intArraya = new int[5] { 1, 2, 3, 4, 5 };
+            int[] intArrayb = new int[5] { 1, 2, 3, 4, 6 };
+            int[] intArraybis = new int[4] { 1, 2, 3, 4 };
+            int[] intArrayter = null;
+            object obja = new object(); object objb = new object();
+            string stra = "42"; string strb = "43";
+            // Assert
+            Assert.False(boolb);
+            Assert.NotEqual(bytea, byteb);
+            Assert.NotEqual(chara, charb);
+            Assert.NotEqual(sbytea, sbyteb);
+            Assert.NotEqual(inta, intb);
+            Assert.NotEqual(uinta, uintb);
+            Assert.NotEqual(longa, longb);
+            Assert.NotEqual(ulonga, ulongb);
+            Assert.NotEqual(boola, boolb);
+            Assert.NotEqual(shorta, shortb);
+            Assert.NotEqual(ushorta, ushortb);
+            Assert.NotEqual(floata, floatb);
+            Assert.NotEqual(intArraya, intArrayb);
+            Assert.NotEqual(intArraya, intArraybis);
+            Assert.NotEqual(intArraya, intArrayter);
+            Assert.NotEqual(stra, strb);
+            Assert.NotSame(obja, objb);
+            Assert.NotEmpty(intArraya);
+        }
+
+        [TestMethod]
+        public void TestNullEmpty()
+        {
+            Debug.WriteLine("Test null, not null, types");
+            // Arrange
+            object objnull = null;
+            object objnotnull = new object();
+            Type typea = typeof(int);
+            Type typeb = typeof(int);
+            Type typec = typeof(long);
+            // Assert
+            Assert.Null(objnull);
+            Assert.NotNull(objnotnull);
+            Assert.IsType(typea, typeb);
+            Assert.IsNotType(typea, typec);
+        }
+
+        [TestMethod]
+        public void TestStringComparison()
+        {
+            Debug.WriteLine("Test string, Contains, EndsWith, StartWith");
+            // Arrange
+            string tocontains = "this text contains and end with contains";
+            string startcontains = "contains start this text";
+            string contains = "contains";
+            string doesnotcontains = "this is totally something else";
+            string empty = string.Empty;
+            string stringnull = null;
+            // Assert
+            Assert.Contains(contains, tocontains);
+            Assert.DoesNotContains(contains, doesnotcontains);
+            Assert.DoesNotContains(contains, empty);
+            Assert.DoesNotContains(contains, stringnull);
+            Assert.StartsWith(contains, startcontains);
+            Assert.EndsWith(contains, tocontains);
+        }
+
+        [Setup]
+        public void RunSetup()
+        {
+            Debug.WriteLine("Setup");
+        }
+
+        public void Nothing()
+        {
+            Debug.WriteLine("Nothing and should not be called");
+        }
+
+        [Cleanup]
+        public void Cleanup()
+        {
+            Debug.WriteLine("Cleanup");
+        }
+    }
+
+    public class SomthingElse
+    {
+        public void NothingReally()
+        {
+            Debug.WriteLine("Test failed: This would never get through");
+        }
+    }
+}

--- a/poc/TestOfTestFrameworkByReference/nano.runsettings
+++ b/poc/TestOfTestFrameworkByReference/nano.runsettings
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+   <!-- Configurations that affect the Test Framework -->
+   <RunConfiguration>
+       <MaxCpuCount>1</MaxCpuCount>
+       <ResultsDirectory>.\TestResults</ResultsDirectory><!-- Path relative to solution directory -->
+       <TestSessionTimeout>120000</TestSessionTimeout><!-- Milliseconds -->
+       <TargetFrameworkVersion>Framework40</TargetFrameworkVersion>
+       <!-- Comment the following line or adjust it if you want to test the TestAdapter. Path has to be absolute or relative to the build folder of the test dll -->
+       <TestAdaptersPaths>C:\Repos\nanoFramework\lib-CoreLibrary\nanoFramework.TestFramework\source\TestAdapter\bin\Debug\net4.8</TestAdaptersPaths>
+   </RunConfiguration>
+   <nanoFrameworkAdapter>
+       <Logging>None</Logging>
+       <IsRealHardware>False</IsRealHardware>
+   </nanoFrameworkAdapter>
+</RunSettings>

--- a/poc/TestOfTestFrameworkByReference/packages.config
+++ b/poc/TestOfTestFrameworkByReference/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.30" targetFramework="netnanoframework10" />
+</packages>

--- a/source/TestAdapter/Properties/launchSettings.json
+++ b/source/TestAdapter/Properties/launchSettings.json
@@ -4,6 +4,11 @@
       "commandName": "Executable",
       "executablePath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\Common7\\IDE\\Extensions\\TestPlatform\\vstest.console.exe",
       "commandLineArgs": "E:\\Github\\nflib-CoreLibrary\\Tests\\NFUnitTestThread\\bin\\Debug\\NFUnitTest.dll  /Settings:E:\\Github\\nflib-CoreLibrary\\Tests\\NFUnitTestThread\\nano.runsettings /TestAdapterPath:."
+    },
+    "nanoFramework.TestAdapter Enterprise": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\Common7\\IDE\\Extensions\\TestPlatform\\vstest.console.exe",
+      "commandLineArgs": "C:\\Repos\\nanoFramework\\lib-CoreLibrary\\nanoFramework.TestFramework\\poc\\TestOfTestFrameworkByReference\\bin\\Debug\\NFUnitTest.dll  /Settings:C:\\Repos\\nanoFramework\\lib-CoreLibrary\\nanoFramework.TestFramework\\poc\\TestOfTestFrameworkByReference\\nano.runsettings /TestAdapterPath:."
     }
   }
 }

--- a/source/TestFramework/TestFramework.cs
+++ b/source/TestFramework/TestFramework.cs
@@ -14,6 +14,21 @@ namespace nanoFramework.TestFramework
     /// </summary>
     public class Assert
     {
+        #region SkipTest
+
+        public static void SkipTest(string message = "")
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                throw new SkipTestException();
+            }
+            else
+            {
+                throw new SkipTestException(message);
+            }
+        }
+
+        #endregion
 
         #region true/false
 
@@ -714,7 +729,7 @@ namespace nanoFramework.TestFramework
         /// </summary>
         /// <param name="exceptionType">The exception to be raised</param>
         /// <param name="action">The method to execute</param>
-        public static void Trows(Type exceptionType, Action action, string message = "")
+        public static void Throws(Type exceptionType, Action action, string message = "")
         {
             try
             {

--- a/source/TestFrameworkShared/SkipTestException.cs
+++ b/source/TestFrameworkShared/SkipTestException.cs
@@ -1,0 +1,41 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+namespace nanoFramework.TestFramework
+{
+    /// <summary>
+    /// To skip a test, raise this exception thru the Assert.SkipTest("some message");
+    /// </summary>
+    public class SkipTestException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the SkipTestException class.
+        /// </summary>
+        public SkipTestException()
+            : base()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the SkipTestException class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public SkipTestException(string message)
+            : base(message)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the SkipTestException class with a specified error message
+        /// and a reference to the inner SkipTestException that is the cause of this exception. 
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException"></param>
+        public SkipTestException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}

--- a/source/TestFrameworkShared/TestFrameworkShared.projitems
+++ b/source/TestFrameworkShared/TestFrameworkShared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CleanupAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SetupAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SkipTestException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestClassAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestMethodAttribute.cs" />
   </ItemGroup>


### PR DESCRIPTION
Adding skipped test, correcting Assert.Throws

## Description

Adding skipped test, correcting Assert.Throws

## Motivation and Context

- Adding skipped test
- Correcting Assert.Throws
- Adding an example by reference in the POC folder to be able to test easily changes in the TestFramework

Important: once merged, the develop-add-skip branch on lib-CoreLibrary should be placed in PR and merged because of the dependencies.

Work on the documentation on its way.

## How Has This Been Tested?<!-- (if applicable) -->

Inception :-) With the framework itself

## Screenshots

![image](https://user-images.githubusercontent.com/8145578/111065617-eecb0c80-84ba-11eb-9435-b5257189e86b.png)

## Types of changes

- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
