### PR TITLE
Fix running Unit Tests for mscorlib in Azure Pipelines

### DIFF
--- a/source/TestAdapter/nanoFramework.TestAdapter.csproj
+++ b/source/TestAdapter/nanoFramework.TestAdapter.csproj
@@ -41,4 +41,12 @@
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
   </Target>
+
+  <!-- need this here to make sure the latest version of WIN32 nanoCLR is used in Azure Pipeline builds -->
+  <Target Name="DownloadWin32NanoClrExe" AfterTargets="Build" Condition="'$(TF_BUILD)' == 'True'">
+      <DownloadFile ContinueOnError="WarnAndContinue" SkipUnchangedFiles="False" SourceUrl="$(Win32_nanoClr_Exe)" DestinationFileName="nanoFramework.nanoCLR.exe" DestinationFolder="$(PkgnanoFramework_nanoCLR_Win32)\lib\net48">
+      <Output TaskParameter="DownloadedFile" ItemName="Content" />
+    </DownloadFile>
+  </Target>
+  
 </Project>


### PR DESCRIPTION
## Description
- Add new target to make sure that the available WIN32 nanoCLR executable is, in fact the latest version.

## Motivation and Context
- Fixes the issue with running Unit Tests for mscorlib in Azure Pipelines when mscorlib signature changes and the nanoCLR is not yet available.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
