### PR TITLE
Add check for parent path in test discoverer

### DIFF
--- a/source/TestAdapter/Discover.cs
+++ b/source/TestAdapter/Discover.cs
@@ -198,10 +198,11 @@ namespace nanoFramework.TestPlatform.TestAdapter
             // if no nfproj file, then we will skip this source
             var mainDirectory = new DirectoryInfo(Path.GetDirectoryName(source));
             var nfproj = mainDirectory.GetFiles("*.nfproj");
-            if (nfproj.Length == 0)
+
+            if (nfproj.Length == 0
+                && mainDirectory.Parent != null)
             {
-                var ret = FindNfprojSources(mainDirectory.Parent.FullName);
-                return ret;
+                return FindNfprojSources(mainDirectory.Parent.FullName);
             }
 
             return nfproj;


### PR DESCRIPTION
## Description
- Add check for parent path in test discoverer.

## Motivation and Context
- Was throwing an exception when there is no parent folder. See test run [here](https://dev.azure.com/nanoframework/metadata-processor/_build/results?buildId=20620&view=logs&j=ecee43a9-35c4-5e0e-e69c-e731648e0eeb&t=a97fb580-a3b4-5f49-d831-b808dd1df18f).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
