### PR TITLE
Improvements in equality comparisons

### DIFF
--- a/source/TestFramework/Assert.cs
+++ b/source/TestFramework/Assert.cs
@@ -120,15 +120,13 @@ namespace nanoFramework.TestFramework
             object actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -143,15 +141,13 @@ namespace nanoFramework.TestFramework
             bool actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -183,15 +179,13 @@ namespace nanoFramework.TestFramework
             int actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -223,15 +217,13 @@ namespace nanoFramework.TestFramework
             Array actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -262,15 +254,13 @@ namespace nanoFramework.TestFramework
             uint actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -301,15 +291,13 @@ namespace nanoFramework.TestFramework
             short actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -340,15 +328,13 @@ namespace nanoFramework.TestFramework
             ushort actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -379,15 +365,13 @@ namespace nanoFramework.TestFramework
             long actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -418,15 +402,13 @@ namespace nanoFramework.TestFramework
             ulong actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -457,15 +439,13 @@ namespace nanoFramework.TestFramework
             byte actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -496,15 +476,13 @@ namespace nanoFramework.TestFramework
             char actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -535,15 +513,13 @@ namespace nanoFramework.TestFramework
             sbyte actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -574,15 +550,13 @@ namespace nanoFramework.TestFramework
             double actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -613,15 +587,13 @@ namespace nanoFramework.TestFramework
             float actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -691,15 +663,13 @@ namespace nanoFramework.TestFramework
             DateTime actual,
             string message = "")
         {
-            if (expected.Equals(actual))
+            if (!object.Equals(expected, actual))
             {
-                return;
+                HandleAreEqualFail(
+                    expected,
+                    actual,
+                    message);
             }
-
-            HandleAreEqualFail(
-                expected,
-                actual,
-                message);
         }
 
         /// <summary>
@@ -734,7 +704,7 @@ namespace nanoFramework.TestFramework
             object actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -755,7 +725,7 @@ namespace nanoFramework.TestFramework
             bool actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -792,7 +762,7 @@ namespace nanoFramework.TestFramework
             int actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -829,7 +799,7 @@ namespace nanoFramework.TestFramework
             Array actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -866,7 +836,7 @@ namespace nanoFramework.TestFramework
             uint actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -903,7 +873,7 @@ namespace nanoFramework.TestFramework
             short actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -940,7 +910,7 @@ namespace nanoFramework.TestFramework
             ushort actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -977,7 +947,7 @@ namespace nanoFramework.TestFramework
             long actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -1015,7 +985,7 @@ namespace nanoFramework.TestFramework
             ulong actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -1052,7 +1022,7 @@ namespace nanoFramework.TestFramework
             byte actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -1089,7 +1059,7 @@ namespace nanoFramework.TestFramework
             char actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -1126,7 +1096,7 @@ namespace nanoFramework.TestFramework
             sbyte actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -1163,7 +1133,7 @@ namespace nanoFramework.TestFramework
             double actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -1200,7 +1170,7 @@ namespace nanoFramework.TestFramework
             float actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,
@@ -1274,7 +1244,7 @@ namespace nanoFramework.TestFramework
             DateTime actual,
             string message = "")
         {
-            if (notExpected.Equals(actual))
+            if (object.Equals(notExpected, actual))
             {
                 HandleAreNotEqualFail(
                     notExpected,

--- a/source/TestFramework/CollectionAssert.cs
+++ b/source/TestFramework/CollectionAssert.cs
@@ -140,7 +140,7 @@ namespace nanoFramework.TestFramework
 
                 while (enumerator.MoveNext() && enumerator2.MoveNext())
                 {
-                    if (!enumerator.Current.Equals(enumerator2.Current))
+                    if (!object.Equals(enumerator.Current, enumerator2.Current))
                     {
                         reason = string.Format(
                             ElementsAtIndexDontMatch,


### PR DESCRIPTION
## Description
- Improve comparisons by using a proper call to `Equal`.
- Simplified `if` in AreEqual asserts.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
