### PR TITLE
Fix issue with results of tests with DataRow

### DIFF
--- a/source/TestAdapter/Discover.cs
+++ b/source/TestAdapter/Discover.cs
@@ -148,13 +148,11 @@ namespace nanoFramework.TestPlatform.TestAdapter
                             var testCase = BuildTestCaseFromSourceFile(
                                 allCsFiles,
                                 typeCandidate,
-                                method,
-                                testMethodAttrib,
-                                i);
+                                method);
 
                             testCase.Source = sourceFile;
                             testCase.ExecutorUri = new Uri(TestsConstants.NanoExecutor);
-                            testCase.FullyQualifiedName = $"{typeCandidate.FullName}.{testCase.DisplayName}";
+                            testCase.FullyQualifiedName = $"{typeCandidate.FullName}.{method.Name}.{i}";
                             testCase.Traits.Add(new Trait("Type", testMethodAttrib.GetType().Name.Replace("Attribute", "")));
 
                             collectionOfTestCases.Add(testCase);
@@ -267,9 +265,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
         private static TestCase BuildTestCaseFromSourceFile(
             string[] csFiles,
             Type className,
-            MethodInfo method,
-            object attribute,
-            int attributeIndex)
+            MethodInfo method)
         {
             TestCase testCase = new TestCase();
 
@@ -296,10 +292,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                     {
                         testCase.CodeFilePath = sourceFile;
                         testCase.LineNumber = lineNumber;
-                        testCase.DisplayName = Helper.GetTestDisplayName(
-                            method,
-                            attribute,
-                            attributeIndex);
+                        testCase.DisplayName = method.Name;
 
                         return testCase;
                     }

--- a/source/TestFrameworkShared/Helper.cs
+++ b/source/TestFrameworkShared/Helper.cs
@@ -27,23 +27,6 @@ namespace nanoFramework.TestFramework
         }
 
         /// <summary>
-        /// Generates test display name based on passed <paramref name="method"/>, <paramref name="attribute"/> and <paramref name="attributeIndex"/>. 
-        /// </summary>
-        /// <returns>Returns method name with attributeIndex if passed attribute is of DataRow type</returns>
-        public static string GetTestDisplayName(MethodInfo method, object attribute, int attributeIndex)
-        {
-            // Comparing via full name, because attribute parameter is from "TestFramework.dll"
-            // and current type TestCaseAttribute is in scope of "TestAdapter" due to shared project
-            // The same reason - reflection to get value
-            if (attribute.GetType().FullName == typeof(DataRowAttribute).FullName)
-            {
-                return $"{method.Name} (index {attributeIndex})";
-            }
-
-            return method.Name;
-        }
-
-        /// <summary>
         /// Removes "TestMethod" attribute from array if "DataRow" attribute exists in the same array
         /// </summary>
         /// <param name="attribs">Array of attributes to check</param>

--- a/source/UnitTestLauncher/Program.cs
+++ b/source/UnitTestLauncher/Program.cs
@@ -74,7 +74,8 @@ namespace nanoFramework.TestFramework
                 for (int i = 0; i < attribs.Length; i++)
                 {
                     var attrib = attribs[i];
-                    var methodName = Helper.GetTestDisplayName(method, attrib, i);
+                    var methodName = $"{method.DeclaringType.FullName}.{method.Name}.{i}";
+
                     if (attribToRun != attrib.GetType())
                     {
                         continue;
@@ -87,13 +88,16 @@ namespace nanoFramework.TestFramework
                         method.Invoke(null, parameters);
                         totalTicks = DateTime.UtcNow.Ticks - dt;
 
-                        Console.WriteLine($"Test passed: {methodName}, {totalTicks}");
+                        // on change this pattern it has to be updated at Executor.CheckAllTests 
+                        Console.WriteLine($"Test passed,{methodName},{totalTicks}");
                     }
                     catch (Exception ex)
                     {
                         if (ex.GetType() == typeof(SkipTestException))
                         {
-                            Console.WriteLine($"Test skipped: {methodName}, {ex.Message}");
+                            // on change this pattern it has to be updated at Executor.CheckAllTests
+                            Console.WriteLine($"Test skipped,{methodName},{ex.Message}");
+
                             if (isSetupMethod)
                             {
                                 // In case the Setup attribute test is skipped, we will skip
@@ -103,7 +107,8 @@ namespace nanoFramework.TestFramework
                         }
                         else
                         {
-                            Console.WriteLine($"Test failed: {methodName}, {ex.Message}");
+                            // on change this pattern it has to be updated at Executor.CheckAllTests 
+                            Console.WriteLine($"Test failed,{methodName},{ex.Message}");
                         }
                     }
                 }


### PR DESCRIPTION
## Description
- Rework output message from test executor.
- Rework test case to use fully qualified name including test index (from DataRow).
- Simplified code in ComposeTestCases  and ParseTestResults (which was renamed for clarity).
- This introduces a breaking change as the test names no longer show the DataRow index (on purpose and following the pattern in classes from full .NET).

## Motivation and Context
- Fixes issue with test results not showing in test explorer becuase of the name pattern. Seems that using `(` and `)` is causing issues begining a recent update on VS testfx.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->
- Test explorer failing to show results (despite the tests are run and present in log.
![image](https://user-images.githubusercontent.com/1881520/229170254-3afcf702-7737-4b41-abbb-c0fe6c4bb0ec.png)

- Test explorer after changes in this PR
![image](https://user-images.githubusercontent.com/1881520/229170373-4cc6e112-f74c-433a-8944-b728a1c4696b.png)

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
