### PR TITLE
CLR helper now updates local CLR instance

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -80,7 +80,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
             try
             {
                 InitializeLogger(runContext, frameworkHandle);
-                
+
                 foreach (var source in sources)
                 {
                     var testsCases = TestDiscoverer.ComposeTestCases(source);
@@ -198,8 +198,8 @@ namespace nanoFramework.TestPlatform.TestAdapter
             var serialDebugClient = PortBase.CreateInstanceForSerial(true, 2000);
 
         retryConnection:
-            
-            if(string.IsNullOrEmpty(_settings.RealHardwarePort))
+
+            if (string.IsNullOrEmpty(_settings.RealHardwarePort))
             {
                 _logger.LogMessage($"Waiting for device enumeration to complete.", Settings.LoggingLevel.Verbose);
             }
@@ -241,7 +241,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 device = serialDebugClient.NanoFrameworkDevices.FirstOrDefault(m => m.SerialNumber == _settings.RealHardwarePort);
 
                 // sanity check
-                if(device is null)
+                if (device is null)
                 {
                     // no device, done here
                     _logger.LogMessage($"No device available at {_settings.RealHardwarePort}.", Settings.LoggingLevel.Verbose);
@@ -595,6 +595,14 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 return results;
             }
 
+            // update nanoCLR instance, if not running a local one
+            if (string.IsNullOrEmpty(_settings.PathToLocalCLRInstance))
+            {
+                NanoCLRHelper.UpdateNanoCLRInstance(
+                    _settings.CLRVersion,
+                    _logger);
+            }
+
             _logger.LogMessage(
                 "Processing assemblies to load into test runner...",
                 Settings.LoggingLevel.Verbose);
@@ -621,7 +629,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
             }
 
             // if requested, set diagnostic output
-            if(_settings.Logging > Settings.LoggingLevel.None)
+            if (_settings.Logging > Settings.LoggingLevel.None)
             {
                 arguments.Append(" -v diag");
             }
@@ -640,7 +648,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
             {
                 var cliResult = await cmd.ExecuteBufferedAsync(cts.Token);
                 var exitCode = cliResult.ExitCode;
-                
+
                 // read standard output
                 var output = cliResult.StandardOutput;
 
@@ -684,7 +692,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
 
                     results.First().Outcome = TestOutcome.Failed;
                     results.First().ErrorMessage = $"nanoCLR execution ended with exit code: {exitCode}. Check log for details.";
-                    
+
                     return results;
                 }
             }
@@ -793,7 +801,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                             var allTestToSkip = results.Where(m => m.TestCase.FullyQualifiedName.Contains(testCasesToSkipName));
                             foreach (var testToSkip in allTestToSkip)
                             {
-                                if(testToSkip.TestCase.FullyQualifiedName == resultDataSet[1])
+                                if (testToSkip.TestCase.FullyQualifiedName == resultDataSet[1])
                                 {
                                     continue;
                                 }

--- a/source/TestAdapter/NanoCLRHelper.cs
+++ b/source/TestAdapter/NanoCLRHelper.cs
@@ -75,5 +75,56 @@ namespace nanoFramework.TestAdapter
             // report outcome
             return NanoClrIsInstalled;
         }
+
+        public static void UpdateNanoCLRInstance(
+            string clrVersion,
+            LogMessenger logger)
+        {
+            logger.LogMessage(
+                "Upate nanoCLR instance",
+                Settings.LoggingLevel.Verbose);
+
+            var arguments = "instance --update";
+
+            if (!string.IsNullOrEmpty(clrVersion))
+            {
+                arguments += $" --clrversion {clrVersion}";
+            }
+
+            var cmd = Cli.Wrap("nanoclr")
+                .WithArguments(arguments)
+                .WithValidation(CommandResultValidation.None);
+
+            // setup cancellation token with a timeout of 1 minute
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
+            {
+                var cliResult = cmd.ExecuteBufferedAsync(cts.Token).Task.Result;
+
+                if (cliResult.ExitCode == 0)
+                {
+                    // this will be either (on update): 
+                    // Updated to v1.8.1.102
+                    // or (on same version):
+                    // Already at v1.8.1.102
+                    var regexResult = Regex.Match(cliResult.StandardOutput, @"((?>version )(?'version'\d+\.\d+\.\d+))");
+
+                    if (regexResult.Success)
+                    {
+                        logger.LogMessage($"nanoCLR instance updated to v{regexResult.Groups["version"].Value}",
+                                          Settings.LoggingLevel.Verbose);
+                    }
+                    else
+                    {
+                        logger.LogPanicMessage($"*** Failed to update nanoCLR instance. {cliResult.StandardOutput}.");
+                    }
+                }
+                else
+                {
+                    logger.LogMessage(
+                        $"Failed to update nanoCLR instance. Exit code {cliResult.ExitCode}.",
+                                          Settings.LoggingLevel.Detailed);
+                }
+            }
+        }
     }
 }

--- a/source/TestAdapter/Settings.cs
+++ b/source/TestAdapter/Settings.cs
@@ -30,6 +30,11 @@ namespace nanoFramework.TestPlatform.TestAdapter
         public string PathToLocalCLRInstance { get; set; } = string.Empty;
 
         /// <summary>
+        /// Version of nanoCLR instance to use when running Unit Tests.
+        /// </summary>
+        public string CLRVersion { get; set; } = string.Empty;
+
+        /// <summary>
         /// Level of logging for test execution.
         /// </summary>
         public LoggingLevel Logging { get; set; } = LoggingLevel.None;
@@ -64,6 +69,12 @@ namespace nanoFramework.TestPlatform.TestAdapter
                     {
                         settings.Logging = logging;
                     }
+                }
+
+                var clrversion = node.SelectSingleNode(nameof(CLRVersion))?.FirstChild;
+                if (clrversion != null && clrversion.NodeType == XmlNodeType.Text)
+                {
+                    settings.CLRVersion = clrversion.Value;
                 }
             }
 

--- a/source/runsettings/nano.runsettings
+++ b/source/runsettings/nano.runsettings
@@ -11,5 +11,6 @@
    <nanoFrameworkAdapter>
        <Logging>None</Logging>
        <IsRealHardware>False</IsRealHardware>
+       <CLRVersion></CLRVersion><!--Specify the nanoCLR version to use. If not specified, the latest available will be used. -->
    </nanoFrameworkAdapter>
 </RunSettings>


### PR DESCRIPTION
## Description
- Add helper method to update nanoCLR instance.
- Add call to update nanoCLR instance when not running a local instance.
- Add new setting to runsettings to allow specify a version to update the nanoCLR instance to.

## Motivation and Context
- Need to make sure that the nanoCLR instance is updated to run unit tests.
- Allow the test adapter to use a specific version of nanoCLR instance to run unit tests.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
