### PR TITLE
Add check to current nanoclr version before attempting update

### DIFF
--- a/source/TestAdapter/NanoCLRHelper.cs
+++ b/source/TestAdapter/NanoCLRHelper.cs
@@ -6,9 +6,12 @@
 using CliWrap;
 using CliWrap.Buffered;
 using nanoFramework.TestPlatform.TestAdapter;
+using Newtonsoft.Json;
 using System;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.ComponentModel;
+using System.Net;
 
 namespace nanoFramework.TestAdapter
 {
@@ -25,50 +28,134 @@ namespace nanoFramework.TestAdapter
                 "Install/upate nanoclr tool",
                 Settings.LoggingLevel.Verbose);
 
-            var cmd = Cli.Wrap("dotnet")
-                .WithArguments("tool update -g nanoclr")
+            // get installed tool version (if installed)
+            var cmd = Cli.Wrap("nanoclr")
+                .WithArguments("--help")
                 .WithValidation(CommandResultValidation.None);
 
-            // setup cancellation token with a timeout of 1 minute
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
+            bool performInstallUpdate = false;
+
+            // setup cancellation token with a timeout of 10 seconds
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            try
             {
                 var cliResult = cmd.ExecuteBufferedAsync(cts.Token).Task.Result;
 
                 if (cliResult.ExitCode == 0)
                 {
-                    // this will be either (on update): 
-                    // Tool 'nanoclr' was successfully updated from version '1.0.205' to version '1.0.208'.
-                    // or (update becoming reinstall with same version, if there is no new version):
-                    // Tool 'nanoclr' was reinstalled with the latest stable version (version '1.0.208').
-                    var regexResult = Regex.Match(cliResult.StandardOutput, @"((?>version ')(?'version'\d+\.\d+\.\d+)(?>'))");
+                    var regexResult = Regex.Match(cliResult.StandardOutput, @"(?'version'\d+\.\d+\.\d+)", RegexOptions.RightToLeft);
 
                     if (regexResult.Success)
                     {
-                        logger.LogMessage($"Install/update successful. Running v{regexResult.Groups["version"].Value}",
-                                          Settings.LoggingLevel.Verbose);
+                        logger.LogMessage($"Running nanoclr v{regexResult.Groups["version"].Value}", Settings.LoggingLevel.Verbose);
+
+                        // compose version
+                        Version installedVersion = new Version(regexResult.Groups[1].Value);
 
                         NanoClrIsInstalled = true;
+                        string responseContent = null;
+
+                        // check latest version
+                        using (System.Net.WebClient client = new WebClient())
+                        {
+                            try
+                            {
+                                // Set the user agent string to identify the client.
+                                client.Headers.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
+
+                                // Set any additional headers, if needed.
+                                client.Headers.Add("Content-Type", "application/json");
+
+                                // Set the URL to request.
+                                string url = "https://api.nuget.org/v3-flatcontainer/nanoclr/index.json";
+
+                                // Make the HTTP request and retrieve the response.
+                                responseContent = client.DownloadString(url);
+                            }
+                            catch (WebException e)
+                            {
+                                // Handle any exceptions that occurred during the request.
+                                Console.WriteLine(e.Message);
+                            }
+                        }
+
+                        var package = JsonConvert.DeserializeObject<NuGetPackage>(responseContent);
+                        Version latestPackageVersion = new Version(package.Versions[package.Versions.Length - 1]);
+
+                        // check if we are running the latest one
+                        if (latestPackageVersion > installedVersion)
+                        {
+                            // need to update
+                            performInstallUpdate = true;
+                        }
+                        else
+                        {
+                            logger.LogMessage($"No need to update. Running v{latestPackageVersion}",
+                                              Settings.LoggingLevel.Verbose);
+                        }
                     }
                     else
                     {
-                        logger.LogPanicMessage($"*** Failed to install/update nanoclr. {cliResult.StandardOutput}.");
+                        // something wrong with the output, can't proceed
+                        logger.LogPanicMessage("Failed to parse current nanoCLR CLI version!");
+                    }
+                }
+            }
+            catch (Win32Exception)
+            {
+                // nanoclr doesn't seem to be installed
+                performInstallUpdate = true;
+                NanoClrIsInstalled = false;
+            }
+
+            if (performInstallUpdate)
+            {
+                cmd = Cli.Wrap("dotnet")
+                .WithArguments("tool update -g nanoclr")
+                .WithValidation(CommandResultValidation.None);
+
+                // setup cancellation token with a timeout of 1 minute
+                using (var cts1 = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
+                {
+                    var cliResult = cmd.ExecuteBufferedAsync(cts1.Token).Task.Result;
+
+                    if (cliResult.ExitCode == 0)
+                    {
+                        // this will be either (on update): 
+                        // Tool 'nanoclr' was successfully updated from version '1.0.205' to version '1.0.208'.
+                        // or (update becoming reinstall with same version, if there is no new version):
+                        // Tool 'nanoclr' was reinstalled with the latest stable version (version '1.0.208').
+                        var regexResult = Regex.Match(cliResult.StandardOutput, @"((?>version ')(?'version'\d+\.\d+\.\d+)(?>'))");
+
+                        if (regexResult.Success)
+                        {
+                            logger.LogMessage($"Install/update successful. Running v{regexResult.Groups["version"].Value}",
+                                              Settings.LoggingLevel.Verbose);
+
+                            NanoClrIsInstalled = true;
+                        }
+                        else
+                        {
+                            logger.LogPanicMessage($"*** Failed to install/update nanoclr. {cliResult.StandardOutput}.");
+
+                            NanoClrIsInstalled = false;
+                        }
+                    }
+                    else
+                    {
+                        logger.LogPanicMessage(
+                            $"Failed to install/update nanoclr. Exit code {cliResult.ExitCode}."
+                            + Environment.NewLine
+                            + Environment.NewLine
+                            + "****************************************"
+                            + Environment.NewLine
+                            + "*** WON'T BE ABLE TO RUN UNITS TESTS ***"
+                            + Environment.NewLine
+                            + "****************************************");
 
                         NanoClrIsInstalled = false;
                     }
-                }
-                else
-                {
-                    logger.LogPanicMessage(
-                        $"Failed to install/update nanoclr. Exit code {cliResult.ExitCode}."
-                        + Environment.NewLine
-                        + Environment.NewLine
-                        + "****************************************"
-                        + Environment.NewLine
-                        + "*** WON'T BE ABLE TO RUN UNITS TESTS ***"
-                        + Environment.NewLine
-                        + "****************************************");
-
-                    NanoClrIsInstalled = false;
                 }
             }
 
@@ -126,5 +213,10 @@ namespace nanoFramework.TestAdapter
                 }
             }
         }
+        internal class NuGetPackage
+        {
+            public string[] Versions { get; set; }
+        }
+
     }
 }

--- a/source/TestAdapter/nanoFramework.TestAdapter.csproj
+++ b/source/TestAdapter/nanoFramework.TestAdapter.csproj
@@ -5,8 +5,10 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <LangVersion>8.0</LangVersion>
     <RestoreLockedMode Condition="'$(TF_BUILD)' == 'True' or '$(ContinuousIntegrationBuild)' == 'True'">true</RestoreLockedMode>
   </PropertyGroup>
 
@@ -19,12 +21,9 @@
       <Version>3.6.128</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Diagnostics.Tracing" />
-  </ItemGroup>
   <Import Project="..\TestFrameworkShared\TestFrameworkShared.projitems" Label="Shared" />
   
 </Project>

--- a/source/TestAdapter/packages.lock.json
+++ b/source/TestAdapter/packages.lock.json
@@ -54,11 +54,11 @@
         "resolved": "3.6.128",
         "contentHash": "zeA+Ho3XlPgt6P9MRALlkEvfOOzDQdNseV0xia/nSfC1lSrl0+gizlWyixaHvSYUw2ru7pBIKnK451bYOjPRjA=="
       },
-      "System.Runtime.CompilerServices.Unsafe": {
+      "Newtonsoft.Json": {
         "type": "Direct",
-        "requested": "[6.0.0, )",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "Fody": {
         "type": "Transitive",
@@ -176,6 +176,11 @@
         "dependencies": {
           "System.Collections.Immutable": "5.0.0"
         }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",


### PR DESCRIPTION
## Description
- Add code to check to current nanoclr version before attempting update.

## Motivation and Context
- Prevents unnecessary reinstall of .NET CLI tool wich is the default behaviour when trying to update it.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
