### PR TITLE
Fix assembly binding for

### DIFF
--- a/source/TestAdapter/App.config
+++ b/source/TestAdapter/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe"
+								  publicKeyToken="b03f5f7f11d50a3a"
+								  culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0"
+								 newVersion="6.0.0.0"/>
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>

--- a/source/TestAdapter/nanoFramework.TestAdapter.csproj
+++ b/source/TestAdapter/nanoFramework.TestAdapter.csproj
@@ -9,6 +9,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <LangVersion>8.0</LangVersion>
+    <AppConfig>App.config</AppConfig>
     <RestoreLockedMode Condition="'$(TF_BUILD)' == 'True' or '$(ContinuousIntegrationBuild)' == 'True'">true</RestoreLockedMode>
   </PropertyGroup>
 

--- a/source/package.nuspec
+++ b/source/package.nuspec
@@ -23,6 +23,7 @@
   </metadata>
   <files>
     <file src="TestAdapter\bin\Release\net4.8\*.dll" target="lib/net48" />
+    <file src="TestAdapter\bin\Release\net4.8\*.config" target="lib/net48" />
     <file src="UnitTestLauncher\bin\Release\nanoFramework.TestFramework.*" target="lib" />
     <file src="UnitTestLauncher\bin\Release\nanoFramework.UnitTestLauncher.*" target="lib" />
     <file src="runsettings\nano.runsettings" target="content" />


### PR DESCRIPTION
## Description
- Properly added app.config to project file.
- Update nuspec to include config file.

## Motivation and Context
- Fixes missing assembly binding. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
