### PR TITLE
Fix getting device following enumeration when `RealHardwarePort` is not set

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -274,11 +274,8 @@ namespace nanoFramework.TestPlatform.TestAdapter
 
             retryCount = 0;
 
-            if (serialDebugClient.NanoFrameworkDevices.Count > 1)
-            {
-                // grab the 1st device available
-                device = serialDebugClient.NanoFrameworkDevices[0];
-            }
+            // grab the 1st device available
+            device = serialDebugClient.NanoFrameworkDevices[0];
 
         executeTests:
 


### PR DESCRIPTION
## Description
- Setting the device local var was failing because of a wrong if clause.

## Motivation and Context
- If `RealHardwarePort` is not set (or empty) in the run.settings file, a device discovery is performed. Following this, provinding that devices are present, the 1st one from the list should be target and set as _the_ device. The if clause was wrong failing to set that device local var which caused a null exception right out of the gate when starting the execute tests section.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running the PoC test app.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
