### PR TITLE
Add CallerArgumentExpression to IsTrue/IsFalse

### DIFF
--- a/source/TestFramework/Assert.cs
+++ b/source/TestFramework/Assert.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using TestFrameworkShared;
 
 namespace nanoFramework.TestFramework
@@ -54,9 +55,7 @@ namespace nanoFramework.TestFramework
         /// <param name="condition">The condition the test expects to be true.</param>
         /// <param name="message">The message to include in the exception when condition is false. The message is shown in test results.</param>
         /// <exception cref="AssertFailedException">Thrown if condition is <see langword="false"/>.</exception>
-        public static void IsTrue(
-            bool condition,
-            string message = "")
+        public static void IsTrue(bool condition, [CallerArgumentExpression(nameof(condition))] string message = "")
         {
             if (!condition)
             {
@@ -83,9 +82,7 @@ namespace nanoFramework.TestFramework
         /// <param name="condition">The condition the test expects to be false.</param>
         /// <param name="message">The message to include in the exception when condition is true. The message is shown in test results.</param>
         /// <exception cref="AssertFailedException">Thrown if condition is <see langword="true"/>.</exception>
-        public static void IsFalse(
-            bool condition,
-            string message = "")
+        public static void IsFalse(bool condition, [CallerArgumentExpression(nameof(condition))] string message = "")
         {
             if (condition)
             {

--- a/source/TestFramework/nanoFramework.TestFramework.nfproj
+++ b/source/TestFramework/nanoFramework.TestFramework.nfproj
@@ -18,6 +18,7 @@
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode Condition="'$(TF_BUILD)' == 'True' or '$(ContinuousIntegrationBuild)' == 'True'">true</RestoreLockedMode>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Add CallerArgumentExpression to IsTrue/IsFalse.

## Motivation and Context
Improved failure messages without additional work / tech debt. Prior to this change a set of tests like the following would all show the same error: "Assert.IsTrue failed."

```C#
var test = new();
Assert.IsTrue(test.Condition1);
Assert.IsTrue(test.Condition2);
Assert.IsTrue(test.Condition3); // Assume this test fails
```

After adding the `CallerArgumentExpressionAttribute` the default failure message changes to "Assert.IsTrue failed. test.Condition3" and it's clear which test failed.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Manually.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
