### PR TITLE
Correct documentation generation for nanoFramework.TestFramework

### DIFF
--- a/source/TestFramework/nanoFramework.TestFramework.nfproj
+++ b/source/TestFramework/nanoFramework.TestFramework.nfproj
@@ -19,6 +19,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode Condition="'$(TF_BUILD)' == 'True' or '$(ContinuousIntegrationBuild)' == 'True'">true</RestoreLockedMode>
     <LangVersion>default</LangVersion>
+    <DocumentationFile>bin\$(Configuration)\nanoFramework.TestFramework.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
## Description
- Other PR: exclude TestOfTestFramework as source for docfx - this is the other test project for the test framework
- This PR: add documentation generation to the TestFramework class library project

## Motivation and Context
The nanoFramework.TestFramework documentation is missing from the API reference, but one of the [test projects](https://docs.nanoframework.net/api/nanoFramework.TestFramework.Test.html) is documented. This PR addresses the first issue that seems to be caused by a missing DocumentationFile element in the nanoFramework.TestFramework's project.

## Test
Verified that the documentation *.xml is now created. Don't know how to test the docfx conversion to markdown.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
