### PR TITLE
Add new setting RunnerExtraArguments to runsettings

### DIFF
--- a/poc/TestOfTestFramework/nano.runsettings
+++ b/poc/TestOfTestFramework/nano.runsettings
@@ -12,5 +12,6 @@
        <IsRealHardware>False</IsRealHardware><!--Set to true to run tests on real hardware. -->
        <CLRVersion></CLRVersion><!--Specify the nanoCLR version to use. If not specified, the latest available will be used. -->
        <PathToLocalCLRInstance></PathToLocalCLRInstance><!--Specify the path to a local nanoCLR instance. If not specified, the default one installed with nanoclr CLR witll be used. -->
+       <RunnerExtraArguments></RunnerExtraArguments><!--Specify extra arguments to pass to the test runner. -->
    </nanoFrameworkAdapter>
 </RunSettings>

--- a/poc/TestOfTestFrameworkByReference/nano.runsettings
+++ b/poc/TestOfTestFrameworkByReference/nano.runsettings
@@ -13,5 +13,6 @@
    <nanoFrameworkAdapter>
        <Logging>None</Logging>
        <IsRealHardware>False</IsRealHardware>
+       <RunnerExtraArguments></RunnerExtraArguments><!--Specify extra arguments to pass to the test runner. -->
    </nanoFrameworkAdapter>
 </RunSettings>

--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -670,6 +670,12 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 arguments.Append(" -v diag");
             }
 
+            // add any extra arguments
+            if (!string.IsNullOrEmpty(_settings.RunnerExtraArguments))
+            {
+                arguments.Append($" {_settings.RunnerExtraArguments} ");
+            }
+
             _logger.LogMessage(
                 $"Launching nanoCLR with these arguments: '{arguments}'",
                 Settings.LoggingLevel.Verbose);

--- a/source/TestAdapter/Settings.cs
+++ b/source/TestAdapter/Settings.cs
@@ -40,6 +40,11 @@ namespace nanoFramework.TestPlatform.TestAdapter
         public LoggingLevel Logging { get; set; } = LoggingLevel.None;
 
         /// <summary>
+        /// Extra arguments to pass to the test runner.
+        /// </summary>
+        public string RunnerExtraArguments { get; set; } = string.Empty;
+
+        /// <summary>
         /// Get settings from an XML node
         /// </summary>
         /// <param name="node"></param>
@@ -81,6 +86,12 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 if (pathtolocalclrinstance != null && pathtolocalclrinstance.NodeType == XmlNodeType.Text)
                 {
                     settings.PathToLocalCLRInstance = pathtolocalclrinstance.Value;
+                }
+
+                var runnerExtraArguments = node.SelectSingleNode(nameof(RunnerExtraArguments))?.FirstChild;
+                if (runnerExtraArguments != null && runnerExtraArguments.NodeType == XmlNodeType.Text)
+                {
+                    settings.RunnerExtraArguments = runnerExtraArguments.Value;
                 }
             }
 


### PR DESCRIPTION
## Description
- Update settings class, parser and executor argument builder.
- Add placeholder for setting in run.settings in PoC projects.

## Motivation and Context
- Allows passing extra arguments to virtual device.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Successfully running both PoC projects passing an extra parameter to nanoclr.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
