### PR TITLE
Fix pattern with file path in Compile entries

### DIFF
--- a/source/TestAdapter/Discover.cs
+++ b/source/TestAdapter/Discover.cs
@@ -215,7 +215,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 var nfprojContent = File.ReadAllText(nfproj.FullName);
 
                 // get all Compile items from the project file
-                string compilePattern = "(?><Compile Include=\")(?<source_file>.+)(?>\")";
+                string compilePattern = "<Compile Include=\"(?<source_file>[^\"]+)\"";
                 var compileItems = Regex.Matches(nfprojContent, compilePattern, RegexOptions.IgnoreCase);
 
                 foreach (System.Text.RegularExpressions.Match compileItem in compileItems)


### PR DESCRIPTION
## Description
- Fix regex expression so it can properly handle compile lines that include Link property.

## Motivation and Context
- Compile lines in nfproj files that contained a Link property were causing an exception as the Regex expression used wasn't dealing with that.
This was failing 
`"<Compile Include="....\nanoFramework.TestFramework\source\TestFramework\Assert.cs" Link="Assert.cs"/>"`

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running mscorling unit tests where this was failing to discover tests.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
