### PR TITLE
Add option to request preview version for nanoCLR

### DIFF
--- a/poc/TestOfTestFramework/nano.runsettings
+++ b/poc/TestOfTestFramework/nano.runsettings
@@ -13,5 +13,6 @@
        <CLRVersion></CLRVersion><!--Specify the nanoCLR version to use. If not specified, the latest available will be used. -->
        <PathToLocalCLRInstance></PathToLocalCLRInstance><!--Specify the path to a local nanoCLR instance. If not specified, the default one installed with nanoclr CLR witll be used. -->
        <RunnerExtraArguments></RunnerExtraArguments><!--Specify extra arguments to pass to the test runner. -->
+       <UsePreviewClr>False</UsePreviewClr><!--Set to true to use the preview version of the nanoCLR. -->
    </nanoFrameworkAdapter>
 </RunSettings>

--- a/poc/TestOfTestFrameworkByReference/nano.runsettings
+++ b/poc/TestOfTestFrameworkByReference/nano.runsettings
@@ -14,5 +14,6 @@
        <Logging>None</Logging>
        <IsRealHardware>False</IsRealHardware>
        <RunnerExtraArguments></RunnerExtraArguments><!--Specify extra arguments to pass to the test runner. -->
+       <UsePreviewClr>False</UsePreviewClr><!--Set to true to use the preview version of the nanoCLR. -->
    </nanoFrameworkAdapter>
 </RunSettings>

--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -670,6 +670,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
             {
                 NanoCLRHelper.UpdateNanoCLRInstance(
                     _settings.CLRVersion,
+                    _settings.UsePreviewClr,
                     _logger);
             }
 

--- a/source/TestAdapter/NanoCLRHelper.cs
+++ b/source/TestAdapter/NanoCLRHelper.cs
@@ -163,8 +163,15 @@ namespace nanoFramework.TestAdapter
             return NanoClrIsInstalled;
         }
 
+        /// <summary>
+        /// Update the nanoCLR instance.
+        /// </summary>
+        /// <param name="clrVersion">Specific version to use.</param>
+        /// <param name="usePreview"><see langword="true"/> to use preview version, <see langword="false"/> to use stable version.</param>
+        /// <param name="logger">The logger to use to log messages.</param>
         public static void UpdateNanoCLRInstance(
             string clrVersion,
+            bool usePreview,
             LogMessenger logger)
         {
             logger.LogMessage(
@@ -173,9 +180,18 @@ namespace nanoFramework.TestAdapter
 
             string arguments = "instance --update";
 
-            if (!string.IsNullOrEmpty(clrVersion))
+            // use preview parameter has precedence over the version
+            if (usePreview)
             {
-                arguments += $" --clrversion {clrVersion}";
+                arguments += " --preview";
+            }
+            else
+            {
+                // if no preview, check if we have a version to use
+                if (!string.IsNullOrEmpty(clrVersion))
+                {
+                    arguments += $" --version {clrVersion}";
+                }
             }
 
             Command cmd = Cli.Wrap("nanoclr")
@@ -183,7 +199,7 @@ namespace nanoFramework.TestAdapter
                 .WithValidation(CommandResultValidation.None);
 
             // setup cancellation token with a timeout of 1 minute
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
+            using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
             {
                 BufferedCommandResult cliResult = cmd.ExecuteBufferedAsync(cts.Token).Task.Result;
 

--- a/source/TestAdapter/Settings.cs
+++ b/source/TestAdapter/Settings.cs
@@ -32,6 +32,14 @@ namespace nanoFramework.TestPlatform.TestAdapter
         public string CLRVersion { get; set; } = string.Empty;
 
         /// <summary>
+        /// <see langword="true"/> to use a preview version of the nanoCLR instance.
+        /// </summary>
+        /// <remarks>
+        /// Set to <see langword="false"/>, or don't set the property, to use the latest stable version.
+        /// </remarks>
+        public bool UsePreviewClr { get; set; } = false;
+
+        /// <summary>
         /// Level of logging for Unit Test execution.
         /// </summary>
         public LoggingLevel Logging { get; set; } = LoggingLevel.None;
@@ -89,6 +97,12 @@ namespace nanoFramework.TestPlatform.TestAdapter
                 if (runnerExtraArguments != null && runnerExtraArguments.NodeType == XmlNodeType.Text)
                 {
                     settings.RunnerExtraArguments = runnerExtraArguments.Value;
+                }
+
+                XmlNode usePreviewClr = node.SelectSingleNode(nameof(UsePreviewClr))?.FirstChild;
+                if (usePreviewClr != null && usePreviewClr.NodeType == XmlNodeType.Text)
+                {
+                    settings.UsePreviewClr = usePreviewClr.Value.Equals("true", StringComparison.CurrentCultureIgnoreCase);
                 }
             }
 


### PR DESCRIPTION
## Description
- Add code to parse option.
- Rework UpdateNanoCLRInstance to use new parameter to for preview version.
- Update runsettings files for testing/template.

## Motivation and Context
- Following nanoframework/nf-interpreter#3156 needed to expose this option.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
