### PR TITLE
Improvements in parsing test execution

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -723,52 +723,50 @@ namespace nanoFramework.TestPlatform.TestAdapter
             // setup cancellation token with the timeout from settings
             using (var cts = new CancellationTokenSource(_testSessionTimeout))
             {
-                var cliResult = await cmd.ExecuteBufferedAsync(cts.Token);
-                var exitCode = cliResult.ExitCode;
+                BufferedCommandResult cliResult = await cmd.ExecuteBufferedAsync(cts.Token);
+                int exitCode = cliResult.ExitCode;
 
                 // read standard output
-                var output = cliResult.StandardOutput;
+                string output = cliResult.StandardOutput;
 
-                if (exitCode == 0)
+                try
                 {
-                    try
+                    // process output to gather tests results
+                    ParseTestResults(output, results);
+
+                    _logger.LogMessage(output, Settings.LoggingLevel.Verbose);
+
+                    if (!output.Contains(Done))
                     {
-                        // process output to gather tests results
-                        ParseTestResults(output, results);
-
-                        _logger.LogMessage(output, Settings.LoggingLevel.Verbose);
-
-                        if (!output.Contains(Done))
-                        {
-                            results.First().Outcome = TestOutcome.Failed;
-                            results.First().ErrorMessage = output;
-                        }
-
-                        var notPassedOrFailed = results.Where(m => m.Outcome != TestOutcome.Failed
-                                                                   && m.Outcome != TestOutcome.Passed
-                                                                   && m.Outcome != TestOutcome.Skipped);
-
-                        if (notPassedOrFailed.Any())
-                        {
-                            notPassedOrFailed.First().ErrorMessage = output;
-                        }
-
+                        results.First(t => t.Outcome == TestOutcome.None).Outcome = TestOutcome.Failed;
+                        results.First(t => t.Outcome == TestOutcome.None).ErrorMessage = output;
                     }
-                    catch (Exception ex)
+
+                    var notPassedOrFailed = results.Where(m => m.Outcome != TestOutcome.Failed
+                                                                && m.Outcome != TestOutcome.Passed
+                                                                && m.Outcome != TestOutcome.Skipped);
+
+                    if (notPassedOrFailed.Any())
                     {
-                        _logger.LogMessage(
-                            $"Fatal exception when processing test results: >>>{ex.Message}\r\n{output}",
-                            Settings.LoggingLevel.Detailed);
-
-                        results.First().Outcome = TestOutcome.Failed;
+                        notPassedOrFailed.Last().ErrorMessage = output;
                     }
+
                 }
-                else
+                catch (Exception ex)
+                {
+                    _logger.LogMessage(
+                        $"Fatal exception when processing test results: >>>{ex.Message}\r\n{output}",
+                        Settings.LoggingLevel.Detailed);
+
+                    results.First(t => t.Outcome == TestOutcome.None).Outcome = TestOutcome.Failed;
+                }
+
+                if (exitCode != 0)
                 {
                     _logger.LogPanicMessage($"nanoCLR ended with '{exitCode}' exit code.\r\n>>>>>>>>>>>>>\r\n{output}\r\n>>>>>>>>>>>>>");
 
-                    results.First().Outcome = TestOutcome.Failed;
-                    results.First().ErrorMessage = $"nanoCLR execution ended with exit code: {exitCode}. Check log for details.";
+                    results.First(t => t.Outcome == TestOutcome.None).Outcome = TestOutcome.Failed;
+                    results.First(t => t.Outcome == TestOutcome.None).ErrorMessage = $"nanoCLR execution ended with exit code: {exitCode}. Check log for details.";
 
                     return results;
                 }


### PR DESCRIPTION
## Description
- Following test run on virtual device, on exit code other than 0, always parse the execution so the test results can be made available.
- Now on failure the first not executed test is showing the detail of the failure.
- Replace var declaration with explicit type in several declarations.

## Motivation and Context
- Need to improve the test result on error or failure to execute. Previously the errors were hammered in the last test, which could be misleading. Moreover, on execution failure, there was no execution parsing making it harder to pinpoint the issue and the test causing the failure.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running some test projects with failing unit tests.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
