### PR TITLE
Fix parser for results with comma

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -800,7 +800,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                     || (line.Contains(TestFailed))
                     || (line.Contains(TestSkipped))))
                 {
-                    resultDataSet = line.Split(',');
+                    resultDataSet = line.Split(new char[] { ',' }, 3);
 
                     // sanity check for enough data
                     if (resultDataSet.Length != 3)


### PR DESCRIPTION
## Description
- Now parses exactly 3 segments, which is aligned with the test output.

## Motivation and Context
- Fixes issue with parser when the test output message includes a comma in the result message. Like this one:
`*** ERROR: can't parse test result Test failed,NFUnitTestConversions.UnitTestConvertTests.Cast_UnsignedToDouble.0,Assert.AreEqual failed. Expected:<2147483648>. Actual:<-2147483648>. Direct cast of (uint expression) to double should be 2147483648, not -2147483648`

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
