### PR TITLE
Hardening result parsing

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -794,11 +794,34 @@ namespace nanoFramework.TestPlatform.TestAdapter
             TestResult testResult = new TestResult(new TestCase());
             string[] resultDataSet = default;
 
-            foreach (var line in outputStrings)
+            foreach (var rawLine in outputStrings)
             {
-                if ((line.Contains(TestPassed)
-                    || (line.Contains(TestFailed))
-                    || (line.Contains(TestSkipped))))
+                string line = rawLine;
+
+                // Some tests write output without ending in a newline, so test result markers can be
+                // concatenated at the end of the same output line.
+                int markerIndex = GetResultMarkerIndex(line);
+
+                if (markerIndex > 0)
+                {
+                    if (readyFound)
+                    {
+                        string outputPrefix = line.Substring(0, markerIndex);
+
+                        if (!string.IsNullOrWhiteSpace(outputPrefix))
+                        {
+                            testOutput.AppendLine(outputPrefix);
+                        }
+                    }
+
+                    line = line.Substring(markerIndex);
+                }
+
+                bool isResultLine = line.StartsWith($"{TestPassed},")
+                    || line.StartsWith($"{TestFailed},")
+                    || line.StartsWith($"{TestSkipped},");
+
+                if (isResultLine)
                 {
                     resultDataSet = line.Split(new char[] { ',' }, 3);
 
@@ -825,7 +848,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                     }
                 }
 
-                if (line.Contains(TestPassed))
+                if (line.StartsWith($"{TestPassed},"))
                 {
                     // Format is "Test passed,MethodName,ticks";
 
@@ -841,7 +864,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                     // reset test output
                     testOutput = new StringBuilder();
                 }
-                else if (line.Contains(TestFailed))
+                else if (line.StartsWith($"{TestFailed},"))
                 {
                     // Format is "Test failed,MethodName,Exception message";
 
@@ -854,7 +877,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
                     // reset test output
                     testOutput = new StringBuilder();
                 }
-                else if (line.Contains(TestSkipped))
+                else if (line.StartsWith($"{TestSkipped},"))
                 {
                     // Format is "Test failed,MethodName,Exception message";
 
@@ -906,6 +929,32 @@ namespace nanoFramework.TestPlatform.TestAdapter
                         readyFound = true;
                     }
                 }
+            }
+
+            int GetResultMarkerIndex(string content)
+            {
+                int passedIndex = content.IndexOf($"{TestPassed},", StringComparison.Ordinal);
+                int failedIndex = content.IndexOf($"{TestFailed},", StringComparison.Ordinal);
+                int skippedIndex = content.IndexOf($"{TestSkipped},", StringComparison.Ordinal);
+
+                int markerIndex = -1;
+
+                if (passedIndex >= 0)
+                {
+                    markerIndex = passedIndex;
+                }
+
+                if (failedIndex >= 0 && (markerIndex < 0 || failedIndex < markerIndex))
+                {
+                    markerIndex = failedIndex;
+                }
+
+                if (skippedIndex >= 0 && (markerIndex < 0 || skippedIndex < markerIndex))
+                {
+                    markerIndex = skippedIndex;
+                }
+
+                return markerIndex;
             }
         }
     }

--- a/source/UnitTestLauncher/Program.cs
+++ b/source/UnitTestLauncher/Program.cs
@@ -84,15 +84,17 @@ namespace nanoFramework.TestFramework
                         method.Invoke(null, parameters);
                         totalTicks = DateTime.UtcNow.Ticks - dt;
 
-                        // on change this pattern it has to be updated at Executor.CheckAllTests 
-                        Console.WriteLine($"Test passed,{methodName},{totalTicks}");
+                        // Keep result markers at the beginning of a line even if a test used Write() without trailing newline.
+                        // On change this pattern it has to be updated at Executor.CheckAllTests.
+                        Console.WriteLine($"\r\nTest passed,{methodName},{totalTicks}");
                     }
                     catch (Exception ex)
                     {
                         if (ex.GetType() == typeof(SkipTestException))
                         {
-                            // on change this pattern it has to be updated at Executor.CheckAllTests
-                            Console.WriteLine($"Test skipped,{methodName},{ex.Message}");
+                            // Keep result markers at the beginning of a line even if a test used Write() without trailing newline.
+                            // On change this pattern it has to be updated at Executor.CheckAllTests.
+                            Console.WriteLine($"\r\nTest skipped,{methodName},{ex.Message}");
 
                             if (isSetupMethod)
                             {
@@ -103,8 +105,9 @@ namespace nanoFramework.TestFramework
                         }
                         else
                         {
-                            // on change this pattern it has to be updated at Executor.CheckAllTests 
-                            Console.WriteLine($"Test failed,{methodName},{ex.Message}");
+                            // Keep result markers at the beginning of a line even if a test used Write() without trailing newline.
+                            // On change this pattern it has to be updated at Executor.CheckAllTests.
+                            Console.WriteLine($"\r\nTest failed,{methodName},{ex.Message}");
                         }
                     }
                 }


### PR DESCRIPTION
## Description
- Making sure results start with new line.
- Improve in parser to handle edge cases with/without new lines/odd formatting/spaces.

## Motivation and Context
- Found in the process of testing new code and unit tests with generics.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
