### PR TITLE
Improve test class discovery

### DIFF
--- a/source/TestAdapter/Discover.cs
+++ b/source/TestAdapter/Discover.cs
@@ -120,7 +120,7 @@ namespace nanoFramework.TestPlatform.TestAdapter
             AppDomain.CurrentDomain.Load(test.GetName());
 
             var typeCandidatesForTests = test.GetTypes()
-                                            .Where(x => x.IsClass);
+                                            .Where(Helper.IsTestClassCandidate);
 
             foreach (var typeCandidate in typeCandidatesForTests)
             {

--- a/source/TestFrameworkShared/Helper.cs
+++ b/source/TestFrameworkShared/Helper.cs
@@ -26,15 +26,27 @@ namespace nanoFramework.TestFramework
         {
             var attributeFullName = typeof(Attribute).FullName;
 
-            for (var current = type; current != null; current = current.BaseType)
+            Type current = type;
+            while (current != null)
             {
                 if (current.FullName == attributeFullName)
                 {
                     return true;
                 }
+                try
+                {
+                    current = current.BaseType;
+                }
+                catch
+                {
+                    // Base type assembly not resolvable in this reflection context;
+                    // conservatively treat as attribute to avoid calling GetCustomAttributes on it.
+                    return true;
+                }
             }
 
             return false;
+
         }
 
         private static bool Any(this object[] array, AnyDelegateType predicate)

--- a/source/TestFrameworkShared/Helper.cs
+++ b/source/TestFrameworkShared/Helper.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace nanoFramework.TestFramework
 {
     /// <summary>
@@ -9,6 +11,31 @@ namespace nanoFramework.TestFramework
     public static class Helper
     {
         private delegate bool AnyDelegateType(object source);
+
+        /// <summary>
+        /// Checks whether a type can be considered for test discovery and execution.
+        /// </summary>
+        /// <param name="type">Type to inspect.</param>
+        /// <returns><see langword="true"/> when the type is a class and not an attribute type.</returns>
+        public static bool IsTestClassCandidate(Type type)
+        {
+            return type.IsClass && !IsAttributeType(type);
+        }
+
+        private static bool IsAttributeType(Type type)
+        {
+            var attributeFullName = typeof(Attribute).FullName;
+
+            for (var current = type; current != null; current = current.BaseType)
+            {
+                if (current.FullName == attributeFullName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private static bool Any(this object[] array, AnyDelegateType predicate)
         {

--- a/source/UnitTestLauncher/Program.cs
+++ b/source/UnitTestLauncher/Program.cs
@@ -22,7 +22,7 @@ namespace nanoFramework.TestFramework
 
             foreach (var type in allTypes)
             {
-                if (!type.IsClass)
+                if (!Helper.IsTestClassCandidate(type))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Description
- Test-class filtering logic moved to shared code so class scanning now excludes Attribute-derived types before calling type-level custom-attribute reflection.

## Motivation and Context
- Running mscorlib unit tests was consistently causing crashes in the test framework runner. Likely cause from crash dump analysis was the minimal support for attributes parsing in nanoFramework CLR. With this change the test class discovery through  attributes is much more targeted without forcing the CLR to parse unsupported named attributes.
 
## How Has This Been Tested?<!-- (IF APPLICABLE) -->


## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
