### PR TITLE
Fix parsing test results for test that can't be found

### DIFF
--- a/source/TestAdapter/Executor.cs
+++ b/source/TestAdapter/Executor.cs
@@ -738,8 +738,12 @@ namespace nanoFramework.TestPlatform.TestAdapter
 
                     if (!output.Contains(Done))
                     {
-                        results.First(t => t.Outcome == TestOutcome.None).Outcome = TestOutcome.Failed;
-                        results.First(t => t.Outcome == TestOutcome.None).ErrorMessage = output;
+                        var firstNoneTest = results.FirstOrDefault(t => t.Outcome == TestOutcome.None);
+                        if (firstNoneTest != null)
+                        {
+                            firstNoneTest.Outcome = TestOutcome.Failed;
+                            firstNoneTest.ErrorMessage = output;
+                        }
                     }
 
                     var notPassedOrFailed = results.Where(m => m.Outcome != TestOutcome.Failed
@@ -758,15 +762,23 @@ namespace nanoFramework.TestPlatform.TestAdapter
                         $"Fatal exception when processing test results: >>>{ex.Message}\r\n{output}",
                         Settings.LoggingLevel.Detailed);
 
-                    results.First(t => t.Outcome == TestOutcome.None).Outcome = TestOutcome.Failed;
+                    var firstNoneTest = results.FirstOrDefault(t => t.Outcome == TestOutcome.None);
+                    if (firstNoneTest != null)
+                    {
+                        firstNoneTest.Outcome = TestOutcome.Failed;
+                    }
                 }
 
                 if (exitCode != 0)
                 {
                     _logger.LogPanicMessage($"nanoCLR ended with '{exitCode}' exit code.\r\n>>>>>>>>>>>>>\r\n{output}\r\n>>>>>>>>>>>>>");
 
-                    results.First(t => t.Outcome == TestOutcome.None).Outcome = TestOutcome.Failed;
-                    results.First(t => t.Outcome == TestOutcome.None).ErrorMessage = $"nanoCLR execution ended with exit code: {exitCode}. Check log for details.";
+                    var firstNoneTest = results.FirstOrDefault(t => t.Outcome == TestOutcome.None);
+                    if (firstNoneTest != null)
+                    {
+                        firstNoneTest.Outcome = TestOutcome.Failed;
+                        firstNoneTest.ErrorMessage = $"nanoCLR execution ended with exit code: {exitCode}. Check log for details.";
+                    }
 
                     return results;
                 }


### PR DESCRIPTION
## Description
- Replace all .First() calls with .FirstOrDefault() and add null checks in ParseTestResults.

## Motivation and Context
- This prevents the exception when tests are missing from the results list (which can happen when test output is missing or malformed).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
