### PR TITLE
Fix several string Asserts

### DIFF
--- a/source/TestFramework/Assert.AreEqual.cs
+++ b/source/TestFramework/Assert.AreEqual.cs
@@ -185,7 +185,7 @@ namespace nanoFramework.TestFramework
         /// <exception cref="AssertFailedException">Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.</exception>
         public static void AreEqual(string expected, string actual, [CallerArgumentExpression(nameof(actual))] string message = "")
         {
-            if (string.Compare(expected, actual) == 0)
+            if (EqualsOrdinal(expected, actual))
             {
                 return;
             }

--- a/source/TestFramework/Assert.AreNotEqual.cs
+++ b/source/TestFramework/Assert.AreNotEqual.cs
@@ -185,7 +185,7 @@ namespace nanoFramework.TestFramework
         /// <exception cref="AssertFailedException">Thrown if <paramref name="notExpected"/> is equal <paramref name="actual"/>.</exception>
         public static void AreNotEqual(string notExpected, string actual, [CallerArgumentExpression(nameof(actual))] string message = "")
         {
-            if (string.Compare(notExpected, actual) == 0)
+            if (EqualsOrdinal(notExpected, actual))
             {
                 HandleAreNotEqualFail(notExpected, actual, message);
             }

--- a/source/TestFramework/Assert.cs
+++ b/source/TestFramework/Assert.cs
@@ -68,7 +68,7 @@ namespace nanoFramework.TestFramework
             EnsureParameterIsNotNull(expected, "Assert.Contains");
             EnsureParameterIsNotNull(value, "Assert.Contains");
 
-            if (value.Contains(expected))
+            if (ContainsOrdinal(value, expected))
             {
                 return;
             }
@@ -88,7 +88,7 @@ namespace nanoFramework.TestFramework
             EnsureParameterIsNotNull(notExpected, "Assert.DoesNotContains");
             EnsureParameterIsNotNull(value, "Assert.DoesNotContains");
 
-            if (!value.Contains(notExpected))
+            if (!ContainsOrdinal(value, notExpected))
             {
                 return;
             }
@@ -108,7 +108,7 @@ namespace nanoFramework.TestFramework
             EnsureParameterIsNotNull(expected, "Assert.EndsWith");
             EnsureParameterIsNotNull(value, "Assert.EndsWith");
 
-            if (value.EndsWith(expected))
+            if (EndsWithOrdinal(value, expected))
             {
                 return;
             }
@@ -151,7 +151,7 @@ namespace nanoFramework.TestFramework
         {
             EnsureParameterIsNotNull(expected, "Assert.IsInstanceOfType");
 
-            if (value is not null && expected == value.GetType())
+            if (value is not null && IsInstanceOfType(value.GetType(), expected))
             {
                 return;
             }
@@ -175,7 +175,7 @@ namespace nanoFramework.TestFramework
         {
             EnsureParameterIsNotNull(notExpected, "Assert.IsNotInstanceOfType");
 
-            if (value is null || notExpected != value.GetType())
+            if (value is null || !IsInstanceOfType(value.GetType(), notExpected))
             {
                 return;
             }
@@ -252,7 +252,7 @@ namespace nanoFramework.TestFramework
             EnsureParameterIsNotNull(expected, "Assert.StartsWith");
             EnsureParameterIsNotNull(value, "Assert.StartsWith");
 
-            if (value.StartsWith(expected))
+            if (StartsWithOrdinal(value, expected))
             {
                 return;
             }
@@ -290,6 +290,131 @@ namespace nanoFramework.TestFramework
             }
 
             HandleFail("Assert.ThrowsException", $"No exception thrown. {exception.Name} exception was expected. {ReplaceNulls(message)}");
+        }
+
+        private static bool IsInstanceOfType(Type actual, Type expected)
+        {
+            if (actual == expected)
+            {
+                return true;
+            }
+
+            if (actual.IsSubclassOf(expected))
+            {
+                return true;
+            }
+
+            if (!expected.IsInterface)
+            {
+                return false;
+            }
+
+            foreach (Type interfaceType in actual.GetInterfaces())
+            {
+                if (interfaceType == expected)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsOrdinal(string value, string search)
+        {
+            if (search.Length == 0)
+            {
+                return true;
+            }
+
+            if (search.Length > value.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i <= value.Length - search.Length; i++)
+            {
+                int j = 0;
+                for (; j < search.Length; j++)
+                {
+                    if (value[i + j] != search[j])
+                    {
+                        break;
+                    }
+                }
+
+                if (j == search.Length)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool StartsWithOrdinal(string value, string prefix)
+        {
+            if (prefix.Length > value.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < prefix.Length; i++)
+            {
+                if (value[i] != prefix[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool EndsWithOrdinal(string value, string suffix)
+        {
+            if (suffix.Length > value.Length)
+            {
+                return false;
+            }
+
+            int startIndex = value.Length - suffix.Length;
+            for (int i = 0; i < suffix.Length; i++)
+            {
+                if (value[startIndex + i] != suffix[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool EqualsOrdinal(string left, string right)
+        {
+            if (left == right)
+            {
+                return true;
+            }
+
+            if (left is null || right is null)
+            {
+                return false;
+            }
+
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (left[i] != right[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         [DoesNotReturn]


### PR DESCRIPTION
## Description
- AreEqual(string, string) now uses ordinal equality.
- AreNotEqual(string, string) now uses ordinal equality.
- Contains, DoesNotContains, StartsWith and EndsWith now use local ordinal string helpers.
- IsInstanceOfType and IsNotInstanceOfType now honor inheritance and interfaces.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
